### PR TITLE
ESP-119_Http_headers_SourceSupport - Add Http header support for Http Lookup Source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add to Http Sink a new properties `gid.connector.http.sink.error.code` and `gid.connector.http.sink.error.code.exclude`
   to set HTTP status code that should be interpreted as errors.
 - Use Flink's format support to Http Lookup Source. 
+- Add HTTP Lookup source client header configuration via properties.
 
 ### Changed
 - Change dependency scope for `org.apache.flink.flink-connector-base` from `compile` to `provided`.

--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ Flink SQL table definition:
 Enrichment Lookup Table
 ```roomsql
 CREATE TABLE Customers (
-	id STRING,
-	id2 STRING,
-	msg STRING,
-	uuid STRING,
-	details ROW<
-	  isActive BOOLEAN,
-	  nestedDetails ROW<
-	    balance STRING
-	  >
-	>
+    id STRING,
+    id2 STRING,
+    msg STRING,
+    uuid STRING,
+    details ROW<
+      isActive BOOLEAN,
+      nestedDetails ROW<
+        balance STRING
+      >
+    >
 ) WITH (
 'connector' = 'rest-lookup',
 'format' = 'json',
@@ -57,9 +57,13 @@ CREATE TABLE Customers (
 'asyncPolling' = 'true'
 )
 ```
+
 Data Source Table
 ```roomsql
-CREATE TABLE Orders (id STRING, id2 STRING, proc_time AS PROCTIME()
+CREATE TABLE Orders (
+    id STRING,
+    id2 STRING,
+    proc_time AS PROCTIME()
 ) WITH (
 'connector' = 'datagen',
 'rows-per-second' = '1',
@@ -70,8 +74,9 @@ CREATE TABLE Orders (id STRING, id2 STRING, proc_time AS PROCTIME()
 'fields.id2.start' = '2',
 'fields.id2.end' = '120'
 );
+```
 
-Using _Customers_ table in Flink SQL Lookup Join with Orders table:
+Using _Customers_ table in Flink SQL Lookup Join with _Orders_ table:
 
 ```roomsql
 SELECT o.id, o.id2, c.msg, c.uuid, c.isActive, c.balance FROM Orders AS o 
@@ -83,6 +88,31 @@ For Example:
 ``
 http://localhost:8080/client/service?id=1&uuid=2
 ``
+#### Http headers
+It is possible to set HTTP headers that will be added to HTTP request send by lookup source connector.
+Headers are defined via property key `gid.connector.http.source.lookup.header.HEADER_NAME = header value` for example:
+`gid.connector.http.source.lookup.header.X-Content-Type-Options = nosniff`.
+
+Headers can be set using http lookup source table DDL. In example below, HTTP request done for `http-lookup` table will contain three headers:
+- `Origin`
+- `X-Content-Type-Options`
+- `Content-Type`
+
+```roomsql
+CREATE TABLE http-lookup (
+  id bigint,
+  some_field string
+) WITH (
+  'connector' = 'rest-lookup',
+  'format' = 'json',
+  'url' = 'http://localhost:8080/client',
+  'asyncPolling' = 'true',
+  'gid.connector.http.source.lookup.header.Origin' = '*',
+  'gid.connector.http.source.lookup.header.X-Content-Type-Options' = 'nosniff',
+  'gid.connector.http.source.lookup.header.Content-Type' = 'application/json'
+)
+```
+
 
 ### HTTP Sink
 The following example shows the minimum Table API example to create a [HttpDynamicSink](src/main/java/com/getindata/connectors/http/internal/table/HttpDynamicSink.java) that writes JSON values to an HTTP endpoint using POST method, assuming Flink has JAR of [JSON serializer](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/connectors/table/formats/json/) installed:
@@ -108,7 +138,7 @@ Due to the fact that `HttpSink` sends bytes inside HTTP request's body, one can 
 
 Other examples of usage of the Table API can be found in [some tests](src/test/java/com/getindata/connectors/http/table/HttpDynamicSinkInsertTest.java).
 
-#### Http headers (currently supported only for HTTP Sink)
+#### Http headers
 It is possible to set HTTP headers that will be added to HTTP request send by sink connector.
 Headers are defined via property key `gid.connector.http.sink.header.HEADER_NAME = header value` for example:
 `gid.connector.http.sink.header.X-Content-Type-Options = nosniff`.

--- a/src/main/java/com/getindata/connectors/http/internal/SinkHttpClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/SinkHttpClient.java
@@ -21,6 +21,8 @@ public interface SinkHttpClient {
      * @return the new {@link CompletableFuture} wrapping {@link SinkHttpClientResponse} that
      * completes when all requests have been sent and returned their statuses
      */
-    CompletableFuture<SinkHttpClientResponse> putRequests(List<HttpSinkRequestEntry> requestEntries,
-        String endpointUrl);
+    CompletableFuture<SinkHttpClientResponse> putRequests(
+        List<HttpSinkRequestEntry> requestEntries,
+        String endpointUrl
+    );
 }

--- a/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
+++ b/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
@@ -23,6 +23,9 @@ public final class HttpConnectorConfigConstants {
      */
     public static final String SINK_HEADER_PREFIX = GID_CONNECTOR_HTTP + "sink.header.";
 
+    public static final String LOOKUP_SOURCE_HEADER_PREFIX = GID_CONNECTOR_HTTP
+        + "source.lookup.header.";
+
     // Error code handling configuration.
     public static final String HTTP_ERROR_CODE_WHITE_LIST =
         GID_CONNECTOR_HTTP + "sink.error.code.exclude";

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupConfig.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupConfig.java
@@ -3,6 +3,7 @@ package com.getindata.connectors.http.internal.table.lookup;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import lombok.Builder;
 import lombok.Data;
@@ -20,4 +21,7 @@ public class HttpLookupConfig implements Serializable {
 
     @Builder.Default
     private final boolean useAsync = false;
+
+    @Builder.Default
+    private final Properties properties = new Properties();
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
@@ -1,6 +1,7 @@
 package com.getindata.connectors.http.internal.table.lookup;
 
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.data.RowData;
@@ -8,13 +9,17 @@ import org.apache.flink.table.data.RowData;
 import com.getindata.connectors.http.internal.PollingClient;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 
-public class RestTablePollingClientFactory implements PollingClientFactory<RowData> {
+public class JavaNetHttpPollingClientFactory implements PollingClientFactory<RowData> {
 
     @Override
     public PollingClient<RowData> createPollClient(
             HttpLookupConfig options,
             DeserializationSchema<RowData> schemaDecoder) {
 
-        return new RestTablePollingClient(HttpClient.newHttpClient(), schemaDecoder, options);
+        HttpClient httpClient = HttpClient.newBuilder()
+            .followRedirects(Redirect.NORMAL)
+            .build();
+
+        return new JavaNetHttpPollingClient(httpClient, schemaDecoder, options);
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicTableSinkFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicTableSinkFactory.java
@@ -25,12 +25,15 @@ public class HttpDynamicTableSinkFactory extends AsyncDynamicTableSinkFactory {
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         final AsyncDynamicSinkContext factoryContext = new AsyncDynamicSinkContext(this, context);
+
+        // This is actually same as calling helper.getOptions();
         ReadableConfig tableOptions = factoryContext.getTableOptions();
 
         // Validate configuration
         FactoryUtil.createTableFactoryHelper(this, context)
             .validateExcept(HttpConnectorConfigConstants.GID_CONNECTOR_HTTP);
         validateHttpSinkOptions(tableOptions);
+
         Properties asyncSinkProperties =
             new AsyncSinkConfigurationValidator(tableOptions).getValidatedConfigurations();
 

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactoryTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactoryTest.java
@@ -7,22 +7,23 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class RestTablePollingClientFactoryTest {
+class JavaNetHttpPollingClientFactoryTest {
 
-    private RestTablePollingClientFactory factory;
+    private JavaNetHttpPollingClientFactory factory;
 
     @BeforeEach
     public void setUp() {
-        factory = new RestTablePollingClientFactory();
+        factory = new JavaNetHttpPollingClientFactory();
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void shouldCreateClient() {
+
         assertThat(
             factory.createPollClient(
-                mock(HttpLookupConfig.class),
+                HttpLookupConfig.builder().build(),
                 (DeserializationSchema<RowData>) mock(DeserializationSchema.class))
-        ).isInstanceOf(RestTablePollingClient.class);
+        ).isInstanceOf(JavaNetHttpPollingClient.class);
     }
 }


### PR DESCRIPTION
Signed-off-by: Krzysztof Chmielewski <krzysztof.chmielewski@getindata.com>

#### Description

Add Http header support for Http Lookup Source.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
