### PR TITLE
ESP-221_BasicAuth - adding HeaderPreprocessor and support for Basic Authentication mechanism.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Added
 
 - Add Http Header value preprocessor mechanism, that can preprocess defined header value before setting it on the request.
-- Allow user to specify `Autorization` header for Basic Authentication. The value will be converted to Base64,
-  or it will be used is if the valued is starting from `Basic ` prefix.
+- Allow user to specify `Authorization` header for Basic Authentication. The value will be converted to Base64,
+  or if it starts from prefix `Basic `, it will be used as is (without any extra modification).
 - Add TLS and mTLS support for Http Sink and Lookup Source connectors.  
 New properties are:
   - `gid.connector.http.security.cert.server` - path to server's certificate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ### Added
 
+- Add Http Header value preprocessor mechanism, that can preprocess defined header value before setting it on the request.
+- Allow user to specify `Autorization` header for Basic Authentication. The value will be converted to Base64,
+  or it will be used is if the valued is starting from `Basic ` prefix.
 - Add TLS and mTLS support for Http Sink and Lookup Source connectors.  
 New properties are:
   - `gid.connector.http.security.cert.server` - path to server's certificate.
   - `gid.connector.http.security.cert.client` - path to connector's certificate.
   - `gid.connector.http.security.key.client` - path to connector's private key.
-  - `gid.connector.http.security.cert.server.allowSelfSigned` - allowing for self signed certificates without adding them to KeyStore (not recommended for a production).
+  - `gid.connector.http.security.cert.server.allowSelfSigned` - allowing for self-signed certificates without adding them to KeyStore (not recommended for a production).
 
 ## [0.4.0] - 2022-08-31
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ To enable this option use `gid.connector.http.security.cert.server.allowSelfSign
 ## Basic Authentication
 Connector supports Basic Authentication mechanism using HTTP `Authorization` header.
 The header value can set via properties same as other headers. Connector will convert passed value to Base64 and use it for request.
-If used value starts from `Basic `, connector will assume that provided value is already converted and will use it as is.
+If the used value starts from prefix `Basic `, it will be used as header value as is, without any extra modification.
 
 ## Table API Connector Options
 ### HTTP TableLookup Source

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ For non production environments it is sometimes necessary to use Https connectio
 In this special case, you can configure connector to trust all certificates without adding them to keystore.
 To enable this option use `gid.connector.http.security.cert.server.allowSelfSigned` property setting its value to `true`.
 
+## Basic Authentication
+Connector supports Basic Authentication mechanism using HTTP `Authorization` header.
+The header value can set via properties same as other headers. Connector will convert passed value to Base64 and use it for request.
+If used value starts from `Basic `, connector will assume that provided value is already converted and will use it as is.
+
 ## Table API Connector Options
 ### HTTP TableLookup Source
 | Option                                                  | Required | Description/Value                                                                                                                                    |

--- a/src/main/java/com/getindata/connectors/http/HttpSink.java
+++ b/src/main/java/com/getindata/connectors/http/HttpSink.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
 import com.getindata.connectors.http.internal.sink.HttpSinkInternal;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
@@ -41,8 +42,10 @@ public class HttpSink<InputT> extends HttpSinkInternal<InputT> {
             long maxRecordSizeInBytes,
             String endpointUrl,
             HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+            HeaderPreprocessor headerPreprocessor,
             SinkHttpClientBuilder sinkHttpClientBuilder,
             Properties properties) {
+
         super(elementConverter,
             maxBatchSize,
             maxInFlightRequests,
@@ -52,6 +55,7 @@ public class HttpSink<InputT> extends HttpSinkInternal<InputT> {
             maxRecordSizeInBytes,
             endpointUrl,
             httpPostRequestCallback,
+            headerPreprocessor,
             sinkHttpClientBuilder,
             properties
         );

--- a/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
+++ b/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
@@ -7,11 +7,13 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.base.sink.AsyncSinkBaseBuilder;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.SinkHttpClient;
 import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 import com.getindata.connectors.http.internal.sink.httpclient.JavaNetSinkHttpClient;
 import com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallback;
+import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 
 /**
  * Builder to construct {@link HttpSink}.
@@ -63,6 +65,9 @@ public class HttpSinkBuilder<InputT> extends
     private static final HttpPostRequestCallback<HttpSinkRequestEntry>
         DEFAULT_POST_REQUEST_CALLBACK = new Slf4jHttpPostRequestCallback();
 
+    private static final HeaderPreprocessor DEFAULT_HEADER_PREPROCESSOR =
+        HttpHeaderUtils.createDefaultHeaderPreprocessor();
+
     private final Properties properties = new Properties();
 
     // Mandatory field
@@ -77,9 +82,13 @@ public class HttpSinkBuilder<InputT> extends
     // If not defined, should be set to DEFAULT_POST_REQUEST_CALLBACK
     private HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback;
 
+    // If not defined, should be set to DEFAULT_HEADER_PREPROCESSOR
+    private HeaderPreprocessor headerPreprocessor;
+
     HttpSinkBuilder() {
         this.sinkHttpClientBuilder = DEFAULT_CLIENT_BUILDER;
         this.httpPostRequestCallback = DEFAULT_POST_REQUEST_CALLBACK;
+        this.headerPreprocessor = DEFAULT_HEADER_PREPROCESSOR;
     }
 
     /**
@@ -119,6 +128,12 @@ public class HttpSinkBuilder<InputT> extends
         return this;
     }
 
+    public HttpSinkBuilder<InputT> setHttpHeaderPreprocessor(
+            HeaderPreprocessor headerPreprocessor) {
+        this.headerPreprocessor = headerPreprocessor;
+        return this;
+    }
+
     /**
      * Set property for Http Sink.
      * @param propertyName property name
@@ -152,6 +167,7 @@ public class HttpSinkBuilder<InputT> extends
             Optional.ofNullable(getMaxRecordSizeInBytes()).orElse(DEFAULT_MAX_RECORD_SIZE_IN_B),
             endpointUrl,
             httpPostRequestCallback,
+            headerPreprocessor,
             sinkHttpClientBuilder,
             properties
         );

--- a/src/main/java/com/getindata/connectors/http/internal/BasicAuthHeaderValuePreprocessor.java
+++ b/src/main/java/com/getindata/connectors/http/internal/BasicAuthHeaderValuePreprocessor.java
@@ -1,0 +1,32 @@
+package com.getindata.connectors.http.internal;
+
+import java.util.Base64;
+
+/**
+ * Header processor for HTTP Basic Authentication mechanism.
+ * Only "Basic" authentication is supported currently.
+ */
+public class BasicAuthHeaderValuePreprocessor implements HeaderValuePreprocessor {
+
+    public static final String BASIC = "Basic ";
+
+    /**
+     * Calculates {@link Base64} value of provided header value. For Basic authentication mechanism,
+     * the raw value is expected to match user:password pattern.
+     * <p>
+     * If rawValue starts with "Basic " prefix it is assumed that this value is already converted to
+     * expected "Authorization" header value.
+     *
+     * @param rawValue header original value to modify.
+     * @return value of "Authorization" header with format "Basic " + Base64 from rawValue or
+     * rawValue without any changes if it starts with "Basic " prefix.
+     */
+    @Override
+    public String preprocessHeaderValue(String rawValue) {
+        if (rawValue.startsWith(BASIC)) {
+            return rawValue;
+        } else {
+            return BASIC + Base64.getEncoder().encodeToString(rawValue.getBytes());
+        }
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/ComposeHeaderPreprocessor.java
+++ b/src/main/java/com/getindata/connectors/http/internal/ComposeHeaderPreprocessor.java
@@ -1,0 +1,44 @@
+package com.getindata.connectors.http.internal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This implementation of {@link HeaderPreprocessor} acts as a registry for all {@link
+ * HeaderValuePreprocessor} that should be applied on HTTP request.
+ */
+public class ComposeHeaderPreprocessor implements HeaderPreprocessor {
+
+    /**
+     * Default, pass through header value preprocessor used whenever dedicated preprocessor for a
+     * given header does not exist.
+     */
+    private static final HeaderValuePreprocessor DEFAULT_VALUE_PREPROCESSOR = rawValue -> rawValue;
+
+    /**
+     * Map with {@link HeaderValuePreprocessor} to apply.
+     */
+    private final Map<String, HeaderValuePreprocessor> valuePreprocessors;
+
+    /**
+     * Creates a new instance of ComposeHeaderPreprocessor for provided {@link
+     * HeaderValuePreprocessor} map.
+     *
+     * @param valuePreprocessors map of {@link HeaderValuePreprocessor} that should be used for this
+     *                           processor. If null, then default, pass through header value
+     *                           processor will be used for every header.
+     */
+    public ComposeHeaderPreprocessor(Map<String, HeaderValuePreprocessor> valuePreprocessors) {
+        this.valuePreprocessors = (valuePreprocessors == null)
+            ? Collections.emptyMap()
+            : new HashMap<>(valuePreprocessors);
+    }
+
+    @Override
+    public String preprocessValueForHeader(String headerName, String headerRawValue) {
+        return valuePreprocessors
+            .getOrDefault(headerName, DEFAULT_VALUE_PREPROCESSOR)
+            .preprocessHeaderValue(headerRawValue);
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/HeaderPreprocessor.java
+++ b/src/main/java/com/getindata/connectors/http/internal/HeaderPreprocessor.java
@@ -1,0 +1,17 @@
+package com.getindata.connectors.http.internal;
+
+import java.io.Serializable;
+
+/**
+ * Interface for header preprocessing
+ */
+public interface HeaderPreprocessor extends Serializable {
+
+    /**
+     * Preprocess value of a header.Preprocessing can change or validate header value.
+     * @param headerName header name which value should be preprocessed.
+     * @param headerRawValue header value to process.
+     * @return preprocessed header value.
+     */
+    String preprocessValueForHeader(String headerName, String headerRawValue);
+}

--- a/src/main/java/com/getindata/connectors/http/internal/HeaderValuePreprocessor.java
+++ b/src/main/java/com/getindata/connectors/http/internal/HeaderValuePreprocessor.java
@@ -3,7 +3,7 @@ package com.getindata.connectors.http.internal;
 import java.io.Serializable;
 
 /**
- * Processor interface that its job is to modify header value based on implemented logic.
+ * Processor interface which modifies header value based on implemented logic.
  * An example would be calculation of Value of Authorization header.
  */
 public interface HeaderValuePreprocessor extends Serializable {

--- a/src/main/java/com/getindata/connectors/http/internal/HeaderValuePreprocessor.java
+++ b/src/main/java/com/getindata/connectors/http/internal/HeaderValuePreprocessor.java
@@ -1,0 +1,18 @@
+package com.getindata.connectors.http.internal;
+
+import java.io.Serializable;
+
+/**
+ * Processor interface that its job is to modify header value based on implemented logic.
+ * An example would be calculation of Value of Authorization header.
+ */
+public interface HeaderValuePreprocessor extends Serializable {
+
+    /**
+     * Modifies header rawValue according to the implemented logic.
+     * @param rawValue header original value to modify
+     * @return modified header value.
+     */
+    String preprocessHeaderValue(String rawValue);
+
+}

--- a/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientBuilder.java
+++ b/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientBuilder.java
@@ -13,8 +13,12 @@ import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
  */
 @PublicEvolving
 public interface SinkHttpClientBuilder extends Serializable {
+
+    // TODO Consider moving HttpPostRequestCallback and HeaderPreprocessor to be a
+    //  SinkHttpClientBuilder fields. This method is getting more and more arguments.
     SinkHttpClient build(
         Properties properties,
-        HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback
+        HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+        HeaderPreprocessor headerPreprocessor
     );
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
@@ -5,7 +5,9 @@ import java.net.http.HttpClient;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.data.RowData;
 
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.PollingClientFactory;
+import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
 
 public class JavaNetHttpPollingClientFactory implements PollingClientFactory<RowData> {
@@ -17,6 +19,11 @@ public class JavaNetHttpPollingClientFactory implements PollingClientFactory<Row
 
         HttpClient httpClient = JavaNetHttpClientFactory.createClient(options.getProperties());
 
-        return new JavaNetHttpPollingClient(httpClient, schemaDecoder, options);
+        // TODO Consider this to be injected as method argument or factory field
+        //  so user could set this using API.
+        HeaderPreprocessor headerPreprocessor = HttpHeaderUtils.createDefaultHeaderPreprocessor();
+
+
+        return new JavaNetHttpPollingClient(httpClient, schemaDecoder, options, headerPreprocessor);
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
@@ -22,6 +22,7 @@ import com.getindata.connectors.http.HttpSink;
 import com.getindata.connectors.http.HttpSinkBuilder;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 import com.getindata.connectors.http.internal.sink.httpclient.JavaNetSinkHttpClient;
+import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.INSERT_METHOD;
 import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.URL;
 
@@ -125,6 +126,8 @@ public class HttpDynamicSink extends AsyncDynamicTableSink<HttpSinkRequestEntry>
             .setEndpointUrl(tableOptions.get(URL))
             .setSinkHttpClientBuilder(JavaNetSinkHttpClient::new)
             .setHttpPostRequestCallback(httpPostRequestCallback)
+            // In future header preprocessor could be set via custom factory
+            .setHttpHeaderPreprocessor(HttpHeaderUtils.createDefaultHeaderPreprocessor())
             .setElementConverter((rowData, _context) -> new HttpSinkRequestEntry(
                 insertMethod,
                 serializationSchema.serialize(rowData)

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallback.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallback.java
@@ -18,6 +18,7 @@ import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
  */
 @Slf4j
 public class Slf4jHttpPostRequestCallback implements HttpPostRequestCallback<HttpSinkRequestEntry> {
+
     @Override
     public void call(
         HttpResponse<String> response,
@@ -38,7 +39,7 @@ public class Slf4jHttpPostRequestCallback implements HttpPostRequestCallback<Htt
                 "Method: {}\n    Body: {}\n  Response: {}\n    Body: {}",
                 requestEntry.method,
                 new String(requestEntry.element, StandardCharsets.UTF_8),
-                response.toString(),
+                response,
                 response.body()
             );
         }

--- a/src/main/java/com/getindata/connectors/http/internal/utils/ConfigUtils.java
+++ b/src/main/java/com/getindata/connectors/http/internal/utils/ConfigUtils.java
@@ -3,7 +3,6 @@ package com.getindata.connectors.http.internal.utils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Stream;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -79,34 +78,6 @@ public final class ConfigUtils {
         }
 
         return propertyKey.substring(delimiterLastIndex + 1);
-    }
-
-    /**
-     * Flat map a given Map of header name and header value map to an array containing both header
-     * names and values. For example, header map of
-     * <pre>{@code
-     *     Map.of(
-     *     header1, val1,
-     *     header2, val2
-     *     )
-     * }</pre>
-     * will be converter to an array of:
-     * <pre>{@code
-     *      String[] headers = {"header1", "val1", "header2", "val2"};
-     * }</pre>
-     *
-     * @param headerMap mapping of header names to header values
-     * @return an array containing both header names and values
-     */
-    public static String[] toHeaderAndValueArray(Map<String, String> headerMap) {
-        return headerMap
-            .entrySet()
-            .stream()
-            .flatMap(entry -> {
-                String originalKey = entry.getKey();
-                String newKey = ConfigUtils.extractPropertyLastElement(originalKey);
-                return Stream.of(newKey, entry.getValue());
-            }).toArray(String[]::new);
     }
 
     private static <T> void tryAddToConfigMap(

--- a/src/main/java/com/getindata/connectors/http/internal/utils/HttpHeaderUtils.java
+++ b/src/main/java/com/getindata/connectors/http/internal/utils/HttpHeaderUtils.java
@@ -1,0 +1,75 @@
+package com.getindata.connectors.http.internal.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import com.getindata.connectors.http.internal.BasicAuthHeaderValuePreprocessor;
+import com.getindata.connectors.http.internal.ComposeHeaderPreprocessor;
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
+
+@NoArgsConstructor(access = AccessLevel.NONE)
+public final class HttpHeaderUtils {
+
+    public static Map<String, String> prepareHeaderMap(
+            String headerKeyPrefix,
+            Properties properties,
+            HeaderPreprocessor headerPreprocessor) {
+
+        //  at this stage headerMap keys are full property paths not only header names.
+        Map<String, String> propertyHeaderMap =
+            ConfigUtils.propertiesToMap(properties, headerKeyPrefix, String.class);
+
+        // Map with keys pointing to the headerName.
+        Map<String, String> headerMap = new HashMap<>();
+
+        for (Entry<String, String> headerAndValue : propertyHeaderMap.entrySet()) {
+            String propertyName = headerAndValue.getKey();
+            String headerValue = headerAndValue.getValue();
+
+            String headerName = ConfigUtils.extractPropertyLastElement(propertyName);
+            headerMap.put(
+                headerName,
+                headerPreprocessor.preprocessValueForHeader(headerName, headerValue)
+            );
+        }
+        return headerMap;
+    }
+
+    /**
+     * Flat map a given Map of header name and header value map to an array containing both header
+     * names and values. For example, header map of
+     * <pre>{@code
+     *     Map.of(
+     *     header1, val1,
+     *     header2, val2
+     *     )
+     * }</pre>
+     * will be converter to an array of:
+     * <pre>{@code
+     *      String[] headers = {"header1", "val1", "header2", "val2"};
+     * }</pre>
+     *
+     * @param headerMap mapping of header names to header values
+     * @return an array containing both header names and values
+     */
+    public static String[] toHeaderAndValueArray(Map<String, String> headerMap) {
+        return headerMap
+            .entrySet()
+            .stream()
+            .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
+            .toArray(String[]::new);
+    }
+
+    public static HeaderPreprocessor createDefaultHeaderPreprocessor() {
+        return new ComposeHeaderPreprocessor(
+            Collections.singletonMap("Authorization", new BasicAuthHeaderValuePreprocessor())
+        );
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/BasicAuthHeaderValuePreprocessorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/BasicAuthHeaderValuePreprocessorTest.java
@@ -1,0 +1,28 @@
+package com.getindata.connectors.http.internal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BasicAuthHeaderValuePreprocessorTest {
+
+    private BasicAuthHeaderValuePreprocessor preprocessor;
+
+    @BeforeEach
+    public void setUp() {
+        this.preprocessor = new BasicAuthHeaderValuePreprocessor();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "user:password, Basic dXNlcjpwYXNzd29yZA==",
+        "Basic dXNlcjpwYXNzd29yZA==, Basic dXNlcjpwYXNzd29yZA=="
+    })
+    public void testAuthorizationHeaderPreprocess(
+            String headerRawValue,
+            String expectedHeaderValue) {
+        String headerValue = this.preprocessor.preprocessHeaderValue(headerRawValue);
+        assertThat(headerValue).isEqualTo(expectedHeaderValue);
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/HttpsConnectionTestBase.java
+++ b/src/test/java/com/getindata/connectors/http/internal/HttpsConnectionTestBase.java
@@ -4,6 +4,8 @@ import java.util.Properties;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
+
 public abstract class HttpsConnectionTestBase {
 
     protected static final int SERVER_PORT = 9090;
@@ -24,8 +26,11 @@ public abstract class HttpsConnectionTestBase {
 
     protected Properties properties;
 
+    protected HeaderPreprocessor headerPreprocessor;
+
     public void setUp() {
         this.properties = new Properties();
+        this.headerPreprocessor = HttpHeaderUtils.createDefaultHeaderPreprocessor();
     }
 
     public void tearDown() {

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
@@ -2,14 +2,12 @@ package com.getindata.connectors.http.internal.sink;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.getindata.connectors.http.HttpPostRequestCallback;
 import com.getindata.connectors.http.HttpSink;
 import com.getindata.connectors.http.internal.SinkHttpClient;
 import com.getindata.connectors.http.internal.SinkHttpClientResponse;
@@ -25,7 +23,9 @@ public class HttpSinkBuilderTest {
             IllegalArgumentException.class,
             () -> HttpSink.<String>builder()
                 .setElementConverter(ELEMENT_CONVERTER)
-                .setSinkHttpClientBuilder(MockHttpClient::new)
+                .setSinkHttpClientBuilder(
+                    (properties, httpPostRequestCallback, headerPreprocessor)
+                        -> new MockHttpClient())
                 .setEndpointUrl("")
                 .build()
         );
@@ -37,7 +37,9 @@ public class HttpSinkBuilderTest {
             IllegalArgumentException.class,
             () -> HttpSink.<String>builder()
                 .setElementConverter(ELEMENT_CONVERTER)
-                .setSinkHttpClientBuilder(MockHttpClient::new)
+                .setSinkHttpClientBuilder(
+                    (properties, httpPostRequestCallback, headerPreprocessor)
+                        -> new MockHttpClient())
                 .build()
         );
     }
@@ -56,14 +58,11 @@ public class HttpSinkBuilderTest {
 
     private static class MockHttpClient implements SinkHttpClient {
 
-        MockHttpClient(
-            Properties properties,
-            HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback) {}
+        MockHttpClient() {}
 
         @Override
         public CompletableFuture<SinkHttpClientResponse> putRequests(
-            List<HttpSinkRequestEntry> requestEntries, String endpointUrl
-        ) {
+            List<HttpSinkRequestEntry> requestEntries, String endpointUrl) {
             throw new RuntimeException("Mock implementation of HttpClient");
         }
     }

--- a/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientTest.java
@@ -14,7 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import static com.getindata.connectors.http.TestHelper.assertPropertyArray;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,11 +26,12 @@ class JavaNetSinkHttpClientTest {
 
     @Mock
     private HttpClient.Builder httpClientBuilder;
-
     @BeforeAll
     public static void beforeAll() {
         httpClientStaticMock = mockStatic(HttpClient.class);
     }
+
+    protected HeaderPreprocessor headerPreprocessor;
 
     @AfterAll
     public static void afterAll() {
@@ -39,6 +42,7 @@ class JavaNetSinkHttpClientTest {
 
     @BeforeEach
     public void setUp() {
+        headerPreprocessor = HttpHeaderUtils.createDefaultHeaderPreprocessor();
         httpClientStaticMock.when(HttpClient::newBuilder).thenReturn(httpClientBuilder);
         when(httpClientBuilder.followRedirects(any())).thenReturn(httpClientBuilder);
         when(httpClientBuilder.sslContext(any())).thenReturn(httpClientBuilder);
@@ -47,7 +51,8 @@ class JavaNetSinkHttpClientTest {
     @Test
     public void shouldBuildClientWithoutHeaders() {
 
-        JavaNetSinkHttpClient client = new JavaNetSinkHttpClient(new Properties());
+        JavaNetSinkHttpClient client =
+            new JavaNetSinkHttpClient(new Properties(), this.headerPreprocessor);
         assertThat(client.getHeadersAndValues()).isEmpty();
     }
 
@@ -72,7 +77,7 @@ class JavaNetSinkHttpClientTest {
         );
 
         // WHEN
-        JavaNetSinkHttpClient client = new JavaNetSinkHttpClient(properties);
+        JavaNetSinkHttpClient client = new JavaNetSinkHttpClient(properties, headerPreprocessor);
         String[] headersAndValues = client.getHeadersAndValues();
         assertThat(headersAndValues).hasSize(6);
 

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
@@ -79,7 +79,7 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
 
         properties.setProperty(HttpConnectorConfigConstants.ALLOW_SELF_SIGNED, "true");
 
-        testPollingClientForHttpConnection();
+        testPollingClientConnection();
     }
 
     @ParameterizedTest
@@ -105,7 +105,7 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
             trustedCert.getAbsolutePath()
         );
 
-        testPollingClientForHttpConnection();
+        testPollingClientConnection();
     }
 
     @ParameterizedTest
@@ -146,7 +146,7 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
             clientPrivateKey.getAbsolutePath()
         );
 
-        testPollingClientForHttpConnection();
+        testPollingClientConnection();
     }
 
     @Test
@@ -189,9 +189,8 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
             serverTrustedCert.getAbsolutePath()
         );
 
-        testPollingClientForHttpConnection();
+        testPollingClientConnection();
     }
-
 
     @ParameterizedTest
     @CsvSource(value = {
@@ -224,7 +223,7 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
         assertThrows(RuntimeException.class, () -> setUpPollingClient(properties));
     }
 
-    private void testPollingClientForHttpConnection() {
+    private void testPollingClientConnection() {
         JavaNetHttpPollingClient pollingClient = setUpPollingClient(properties);
         RowData result = pollingClient.pull(
             List.of(

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientTest.java
@@ -5,13 +5,16 @@ import java.util.Properties;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.data.RowData;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import static com.getindata.connectors.http.TestHelper.assertPropertyArray;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,13 +26,22 @@ public class JavaNetHttpPollingClientTest {
     @Mock
     private DeserializationSchema<RowData> decoder;
 
+    private HeaderPreprocessor headerPreprocessor;
+
+    @BeforeEach
+    public void setUp() {
+        this.headerPreprocessor = HttpHeaderUtils.createDefaultHeaderPreprocessor();
+    }
+
     @Test
     public void shouldBuildClientWithoutHeaders() {
 
         JavaNetHttpPollingClient client = new JavaNetHttpPollingClient(
             httpClient,
             decoder,
-            HttpLookupConfig.builder().build());
+            HttpLookupConfig.builder().build(),
+            headerPreprocessor
+        );
         assertThat(client.getHeadersAndValues()).isEmpty();
     }
 
@@ -61,7 +73,8 @@ public class JavaNetHttpPollingClientTest {
         JavaNetHttpPollingClient client = new JavaNetHttpPollingClient(
             httpClient,
             decoder,
-            lookupConfig
+            lookupConfig,
+            headerPreprocessor
         );
 
         String[] headersAndValues = client.getHeadersAndValues();

--- a/src/test/java/com/getindata/connectors/http/internal/utils/ConfigUtilsTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/utils/ConfigUtilsTest.java
@@ -94,11 +94,11 @@ class ConfigUtilsTest {
     public void flatMapPropertyMap() {
         Map<String, String> propertyMap = Map.of(
             "propertyOne", "val1",
-            "my.propertyTwo", "val2",
-            "my.super.propertyThree", "val3"
+            "propertyTwo", "val2",
+            "propertyThree", "val3"
         );
 
-        String[] propertyArray = ConfigUtils.toHeaderAndValueArray(propertyMap);
+        String[] propertyArray = HttpHeaderUtils.toHeaderAndValueArray(propertyMap);
 
         // size is == propertyMap.key size + propertyMap.value.size
         assertThat(propertyArray).hasSize(6);


### PR DESCRIPTION
Signed-off-by: Krzysztof Chmielewski <krzysztof.chmielewski@getindata.com>

#### Description
Add Http Header value preprocessor mechanism, that can preprocess defined header value before setting it on the request.
It allows user to specify `Autorization` header for Basic Authentication. The value will be converted to Base64,
  or it will be used is if the valued is starting from `Basic ` prefix.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
