### PR TITLE
Adapt Http Lookup Source to Elastic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ New properties are:
   - `gid.connector.http.security.cert.client` - path to connector's certificate.
   - `gid.connector.http.security.key.client` - path to connector's private key.
   - `gid.connector.http.security.cert.server.allowSelfSigned` - allowing for self-signed certificates without adding them to KeyStore (not recommended for a production).
+- Add [LookupQueryCreator](src/main/java/com/getindata/connectors/http/LookupQueryCreator.java) and
+  [LookupQueryCreatorFactory](src/main/java/com/getindata/connectors/http/LookupQueryCreatorFactory.java) interfaces 
+  (along with a "default"
+  [GenericGetQueryCreator](src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java)
+  implementation) for customization of queries prepared by Lookup Source for its HTTP requests.
 
 ## [0.4.0] - 2022-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ New properties are:
   (along with a "default"
   [GenericGetQueryCreator](src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java)
   implementation) for customization of queries prepared by Lookup Source for its HTTP requests.
+- Add [ElasticSearchLiteQueryCreator](src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreator.java)
+  that prepares [`q` parameter query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-api-query-params-q)
+  using Lucene query string syntax (in first versions of ElasticSearch called
+  [Search _Lite_](https://www.elastic.co/guide/en/elasticsearch/guide/current/search-lite.html)).
 
 ## [0.4.0] - 2022-08-31
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ CREATE TABLE http-lookup (
 )
 ```
 
+#### Custom REST query
+Http Lookup Source builds queries out of `JOIN` clauses. One can customize how those queries are built by implementing
+[LookupQueryCreator](src/main/java/com/getindata/connectors/http/LookupQueryCreator.java) and
+[LookupQueryCreatorFactory](src/main/java/com/getindata/connectors/http/LookupQueryCreatorFactory.java) interfaces.
+Custom implementations of `LookupQueryCreatorFactory` can be registered along other factories in
+`resources/META-INF.services/org.apache.flink.table.factories.Factory` file and then referenced by their identifiers in
+the Http Lookup Source DDL property field `gid.connector.http.source.lookup.query-creator`.
+
+A default implementation that builds an "ordinary" GET query, i.e. adds `?joinColumn1=value1&joinColumn2=value2&...`
+to the URI of the endpoint,
+([GenericGetQueryCreator](src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java))
+is provided and set as a default.
 
 ### HTTP Sink
 The following example shows the minimum Table API example to create a [HttpDynamicSink](src/main/java/com/getindata/connectors/http/internal/table/HttpDynamicSink.java) that writes JSON values to an HTTP endpoint using POST method, assuming Flink has JAR of [JSON serializer](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/connectors/table/formats/json/) installed:

--- a/src/main/java/com/getindata/connectors/http/LookupArg.java
+++ b/src/main/java/com/getindata/connectors/http/LookupArg.java
@@ -1,4 +1,4 @@
-package com.getindata.connectors.http.internal.table.lookup;
+package com.getindata.connectors.http;
 
 import lombok.Data;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/getindata/connectors/http/LookupQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/LookupQueryCreator.java
@@ -1,0 +1,22 @@
+package com.getindata.connectors.http;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * An interface for a creator of a lookup query in the Http Lookup Source (e.g., the query that
+ * gets appended to the URI in GET request).
+ *
+ * <p>One can customize how those queries are built by implementing {@link LookupQueryCreator} and
+ * {@link LookupQueryCreatorFactory}.
+ */
+public interface LookupQueryCreator extends Serializable {
+    /**
+     * Create a lookup query (like the query appended to path in GET request)
+     * out of the provided arguments.
+     *
+     * @param params the list of {@link LookupArg} containing request parameters.
+     * @return a lookup query.
+     */
+    String createLookupQuery(List<LookupArg> params);
+}

--- a/src/main/java/com/getindata/connectors/http/LookupQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/LookupQueryCreatorFactory.java
@@ -1,0 +1,37 @@
+package com.getindata.connectors.http;
+
+import org.apache.flink.table.factories.Factory;
+
+import com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSource;
+
+/**
+ * The {@link Factory} that dynamically creates and injects {@link LookupQueryCreator} to
+ * {@link HttpLookupTableSource}.
+ *
+ * <p>Custom implementations of {@link LookupQueryCreatorFactory} can be registered along other
+ * factories in <pre>resources/META-INF.services/org.apache.flink.table.factories.Factory</pre>
+ * file and then referenced by their identifiers in the HttpLookupSource DDL property field
+ * <i>gid.connector.http.source.lookup.query-creator</i>.
+ *
+ * <p>The following example shows the minimum Table API example to create a
+ * {@link HttpLookupTableSource} that uses a custom query creator created by a factory that returns
+ * <i>my-query-creator</i> as its identifier.
+ *
+ * <pre>{@code
+ * CREATE TABLE http (
+ *   id bigint,
+ *   some_field string
+ * ) WITH (
+ *   'connector' = 'rest-lookup',
+ *   'format' = 'json',
+ *   'url' = 'http://example.com/myendpoint',
+ *   'gid.connector.http.source.lookup.query-creator' = 'my-query-creator'
+ * )
+ * }</pre>
+ */
+public interface LookupQueryCreatorFactory extends Factory {
+    /**
+     * @return {@link LookupQueryCreator} custom lookup query creator instance
+     */
+    LookupQueryCreator createLookupQueryCreator();
+}

--- a/src/main/java/com/getindata/connectors/http/internal/PollingClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/PollingClient.java
@@ -3,7 +3,7 @@ package com.getindata.connectors.http.internal;
 import java.util.List;
 import java.util.Optional;
 
-import com.getindata.connectors.http.internal.table.lookup.LookupArg;
+import com.getindata.connectors.http.LookupArg;
 
 /**
  * A client that is used to get enrichment data from external component.

--- a/src/main/java/com/getindata/connectors/http/internal/PollingClientFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/PollingClientFactory.java
@@ -4,12 +4,14 @@ import java.io.Serializable;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 
+import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.table.lookup.HttpLookupConfig;
 
 public interface PollingClientFactory<OUT> extends Serializable {
 
     PollingClient<OUT> createPollClient(
         HttpLookupConfig options,
-        DeserializationSchema<OUT> schemaDecoder
+        DeserializationSchema<OUT> schemaDecoder,
+        LookupQueryCreator lookupQueryCreator
     );
 }

--- a/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
+++ b/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
@@ -42,6 +42,9 @@ public final class HttpConnectorConfigConstants {
     public static final String SINK_REQUEST_CALLBACK_IDENTIFIER =
         GID_CONNECTOR_HTTP + "sink.request-callback";
 
+    public static final String SOURCE_LOOKUP_QUERY_CREATOR_IDENTIFIER =
+        GID_CONNECTOR_HTTP + "source.lookup.query-creator";
+
     // -------------- HTTPS security settings --------------
     public static final String ALLOW_SELF_SIGNED =
         GID_CONNECTOR_HTTP + "security.cert.server.allowSelfSigned";

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupConnectorOptions.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupConnectorOptions.java
@@ -3,6 +3,9 @@ package com.getindata.connectors.http.internal.table.lookup;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
+import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreatorFactory;
+import static com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants.SOURCE_LOOKUP_QUERY_CREATOR_IDENTIFIER;
+
 public class HttpLookupConnectorOptions {
 
     public static final ConfigOption<String> URL =
@@ -22,4 +25,9 @@ public class HttpLookupConnectorOptions {
             .booleanType()
             .defaultValue(false)
             .withDescription("Whether to use Sync and Async polling mechanism");
+
+    public static final ConfigOption<String> LOOKUP_QUERY_CREATOR_IDENTIFIER =
+        ConfigOptions.key(SOURCE_LOOKUP_QUERY_CREATOR_IDENTIFIER)
+            .stringType()
+            .defaultValue(GenericGetQueryCreatorFactory.IDENTIFIER);
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
@@ -15,6 +15,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
+import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 import com.getindata.connectors.http.internal.table.lookup.HttpTableLookupFunction.ColumnData;
 
@@ -30,6 +31,8 @@ public class HttpLookupTableSource
     private final HttpLookupConfig lookupConfig;
 
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
+
+    private final LookupQueryCreator lookupQueryCreator;
 
     @Override
     public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
@@ -50,7 +53,8 @@ public class HttpLookupTableSource
             physicalRowDataType,
             pollingClientFactory,
             lookupConfig,
-            decodingFormat
+            decodingFormat,
+            lookupQueryCreator
         );
     }
 
@@ -80,6 +84,7 @@ public class HttpLookupTableSource
                 .pollingClientFactory(pollingClientFactory)
                 .schemaDecoder(schemaDecoder)
                 .columnData(columnData)
+                .lookupQueryCreator(lookupQueryCreator)
                 .options(lookupConfig)
                 .build();
 

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSourceFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSourceFactory.java
@@ -25,12 +25,11 @@ import org.apache.flink.table.types.DataType;
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.types.utils.DataTypeUtils.removeTimeAttribute;
 
+import com.getindata.connectors.http.LookupQueryCreatorFactory;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
 import com.getindata.connectors.http.internal.utils.ConfigUtils;
-import static com.getindata.connectors.http.internal.table.lookup.HttpLookupConnectorOptions.ASYNC_POLLING;
-import static com.getindata.connectors.http.internal.table.lookup.HttpLookupConnectorOptions.URL;
-import static com.getindata.connectors.http.internal.table.lookup.HttpLookupConnectorOptions.URL_ARGS;
+import static com.getindata.connectors.http.internal.table.lookup.HttpLookupConnectorOptions.*;
 
 public class HttpLookupTableSourceFactory implements DynamicTableSourceFactory {
 
@@ -61,6 +60,13 @@ public class HttpLookupTableSourceFactory implements DynamicTableSourceFactory {
                 FactoryUtil.FORMAT
             );
 
+        final LookupQueryCreatorFactory lookupQueryCreatorFactory =
+            FactoryUtil.discoverFactory(
+                context.getClassLoader(),
+                LookupQueryCreatorFactory.class,
+                readableConfig.get(LOOKUP_QUERY_CREATOR_IDENTIFIER)
+            );
+
         PollingClientFactory<RowData> pollingClientFactory = new JavaNetHttpPollingClientFactory();
         HttpLookupConfig lookupConfig = getHttpLookupOptions(context, readableConfig);
 
@@ -73,7 +79,8 @@ public class HttpLookupTableSourceFactory implements DynamicTableSourceFactory {
             physicalRowDataType,
             pollingClientFactory,
             lookupConfig,
-            decodingFormat
+            decodingFormat,
+            lookupQueryCreatorFactory.createLookupQueryCreator()
         );
     }
 

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
@@ -5,6 +5,7 @@ import java.net.http.HttpClient;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.data.RowData;
 
+import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
@@ -14,8 +15,9 @@ public class JavaNetHttpPollingClientFactory implements PollingClientFactory<Row
 
     @Override
     public JavaNetHttpPollingClient createPollClient(
-            HttpLookupConfig options,
-            DeserializationSchema<RowData> schemaDecoder) {
+        HttpLookupConfig options,
+        DeserializationSchema<RowData> schemaDecoder,
+        LookupQueryCreator lookupQueryCreator) {
 
         HttpClient httpClient = JavaNetHttpClientFactory.createClient(options.getProperties());
 
@@ -23,7 +25,12 @@ public class JavaNetHttpPollingClientFactory implements PollingClientFactory<Row
         //  so user could set this using API.
         HeaderPreprocessor headerPreprocessor = HttpHeaderUtils.createDefaultHeaderPreprocessor();
 
-
-        return new JavaNetHttpPollingClient(httpClient, schemaDecoder, options, headerPreprocessor);
+        return new JavaNetHttpPollingClient(
+            httpClient,
+            schemaDecoder,
+            options,
+            lookupQueryCreator,
+            headerPreprocessor
+        );
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreator.java
@@ -1,0 +1,34 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.getindata.connectors.http.LookupArg;
+import com.getindata.connectors.http.LookupQueryCreator;
+
+/**
+ * A {@link LookupQueryCreator} that prepares <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-api-query-params-q"><code>q</code> parameter query</a>
+ * for ElasticSearch <i>Search API</i> using Lucene query string syntax (in first versions of the
+ * ElasticSearch called <a href="https://www.elastic.co/guide/en/elasticsearch/guide/current/search-lite.html">Search <i>Lite</i></a>).
+ */
+public class ElasticSearchLiteQueryCreator implements LookupQueryCreator {
+    private static final String ENCODED_SPACE = "%20";
+    private static final String ENCODED_QUOTATION_MARK = "%22";
+
+    @Override
+    public String createLookupQuery(List<LookupArg> params) {
+        var luceneQuery = params.stream()
+            .map(ElasticSearchLiteQueryCreator::processLookupArg)
+            .collect(Collectors.joining(ENCODED_SPACE + "AND" + ENCODED_SPACE));
+
+        return luceneQuery.isEmpty() ? "" : ("q=" + luceneQuery);
+    }
+
+    private static String processLookupArg(LookupArg arg) {
+        return arg.getArgName()
+               + ":"
+               + ENCODED_QUOTATION_MARK
+               + arg.getArgValue()
+               + ENCODED_QUOTATION_MARK;
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorFactory.java
@@ -1,0 +1,35 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.util.Set;
+
+import org.apache.flink.configuration.ConfigOption;
+
+import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.LookupQueryCreatorFactory;
+
+/**
+ * Factory for creating {@link ElasticSearchLiteQueryCreator}.
+ */
+public class ElasticSearchLiteQueryCreatorFactory implements LookupQueryCreatorFactory {
+    public static final String IDENTIFIER = "elasticsearch-lite";
+
+    @Override
+    public LookupQueryCreator createLookupQueryCreator() {
+        return new ElasticSearchLiteQueryCreator();
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Set.of();
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java
@@ -1,0 +1,25 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.getindata.connectors.http.LookupArg;
+import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.internal.utils.uri.NameValuePair;
+import com.getindata.connectors.http.internal.utils.uri.URLEncodedUtils;
+
+/**
+ * A {@link LookupQueryCreator} that builds an "ordinary" GET query, i.e. adds
+ * <code>joinColumn1=value1&amp;joinColumn2=value2&amp;...</code> to the URI of the endpoint.
+ */
+public class GenericGetQueryCreator implements LookupQueryCreator {
+    @Override
+    public String createLookupQuery(List<LookupArg> params) {
+        return URLEncodedUtils.format(
+            params.stream()
+                  .map(arg -> new NameValuePair(arg.getArgName(), arg.getArgValue()))
+                  .collect(Collectors.toList()),
+            StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreatorFactory.java
@@ -1,0 +1,35 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.util.Set;
+
+import org.apache.flink.configuration.ConfigOption;
+
+import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.LookupQueryCreatorFactory;
+
+/**
+ * Factory for creating {@link GenericGetQueryCreator}.
+ */
+public class GenericGetQueryCreatorFactory implements LookupQueryCreatorFactory {
+    public static final String IDENTIFIER = "generic-get-query";
+
+    @Override
+    public LookupQueryCreator createLookupQueryCreator() {
+        return new GenericGetQueryCreator();
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Set.of();
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/utils/uri/NameValuePair.java
+++ b/src/main/java/com/getindata/connectors/http/internal/utils/uri/NameValuePair.java
@@ -36,7 +36,7 @@ import lombok.Data;
 import org.apache.flink.util.Preconditions;
 
 @Data
-class NameValuePair {
+public class NameValuePair {
 
     private final String name;
 
@@ -48,7 +48,7 @@ class NameValuePair {
      * @param name The name.
      * @param value The value.
      */
-    NameValuePair(final String name, final String value) {
+    public NameValuePair(final String name, final String value) {
         super();
         this.name = Preconditions.checkNotNull(name, "Name may not be null");
         this.value = value;

--- a/src/main/java/com/getindata/connectors/http/internal/utils/uri/URLEncodedUtils.java
+++ b/src/main/java/com/getindata/connectors/http/internal/utils/uri/URLEncodedUtils.java
@@ -46,7 +46,7 @@ import org.apache.flink.util.Preconditions;
 /**
  * A collection of utilities for encoding URLs.
  */
-class URLEncodedUtils {
+public class URLEncodedUtils {
 
     private static final char QP_SEP_A = '&';
 
@@ -310,9 +310,10 @@ class URLEncodedUtils {
      * @param charset    The encoding to use.
      * @return An {@code application/x-www-form-urlencoded} string
      */
-    static String format(
+    public static String format(
         final Iterable<? extends NameValuePair> parameters,
-        final Charset charset) {
+        final Charset charset
+    ) {
         return format(parameters, QP_SEP_A, charset);
     }
 

--- a/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,3 +1,4 @@
 com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSourceFactory
+com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreatorFactory
 com.getindata.connectors.http.internal.table.sink.HttpDynamicTableSinkFactory
 com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallbackFactory

--- a/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,4 +1,5 @@
 com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSourceFactory
+com.getindata.connectors.http.internal.table.lookup.querycreators.ElasticSearchLiteQueryCreatorFactory
 com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreatorFactory
 com.getindata.connectors.http.internal.table.sink.HttpDynamicTableSinkFactory
 com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallbackFactory

--- a/src/test/java/com/getindata/connectors/http/internal/ComposeHeaderPreprocessorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/ComposeHeaderPreprocessorTest.java
@@ -1,0 +1,21 @@
+package com.getindata.connectors.http.internal;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComposeHeaderPreprocessorTest {
+    @ParameterizedTest
+    @CsvSource({
+        "a, a",
+        "a123, a123",
+        "user:password, user:password",
+        "Basic dXNlcjpwYXNzd29yZA==, Basic dXNlcjpwYXNzd29yZA=="
+    })
+    public void testNoPreprocessors(String rawValue, String expectedValue) {
+        var noPreprocessorHeaderPreprocessor = new ComposeHeaderPreprocessor(null);
+        var obtainedValue = noPreprocessorHeaderPreprocessor
+            .preprocessValueForHeader("someHeader", rawValue);
+        assertThat(obtainedValue).isEqualTo(expectedValue);
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/HttpRowDataLookupFunctionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/HttpRowDataLookupFunctionTest.java
@@ -20,9 +20,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.getindata.connectors.http.LookupArg;
+import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.PollingClient;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 import com.getindata.connectors.http.internal.table.lookup.HttpTableLookupFunction.ColumnData;
+import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
 
 @ExtendWith(MockitoExtension.class)
 class HttpRowDataLookupFunctionTest {
@@ -50,6 +53,7 @@ class HttpRowDataLookupFunctionTest {
     @BeforeEach
     void setUp() throws Exception {
         HttpLookupConfig lookupConfig = HttpLookupConfig.builder().build();
+        LookupQueryCreator lookupQueryCreator = new GenericGetQueryCreator();
 
         ColumnData columnData =
             ColumnData.builder()
@@ -57,13 +61,15 @@ class HttpRowDataLookupFunctionTest {
                 .build();
 
         when(functionContext.getMetricGroup()).thenReturn(mock(MetricGroup.class));
-        when(pollingClientFactory.createPollClient(lookupConfig, schemaDecoder)).thenReturn(client);
+        when(pollingClientFactory.createPollClient(lookupConfig, schemaDecoder, lookupQueryCreator))
+            .thenReturn(client);
 
         lookupFunction = HttpTableLookupFunction.builder()
             .pollingClientFactory(pollingClientFactory)
             .schemaDecoder(schemaDecoder)
             .columnData(columnData)
             .options(lookupConfig)
+            .lookupQueryCreator(lookupQueryCreator)
             .build();
 
         lookupFunction.open(functionContext);

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientConnectionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientConnectionTest.java
@@ -36,7 +36,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.getindata.connectors.http.LookupArg;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
 import static com.getindata.connectors.http.TestHelper.readTestFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -260,7 +262,8 @@ class JavaNetHttpPollingClientConnectionTest {
                 .createDecodingFormat(dynamicTableFactoryContext, new Configuration())
                 .createRuntimeDecoder(dynamicTableSourceContext, physicalDataType);
 
-        return pollingClientFactory.createPollClient(lookupConfig, schemaDecoder);
+        return pollingClientFactory
+            .createPollClient(lookupConfig, schemaDecoder, new GenericGetQueryCreator());
     }
 
     private StubMapping setupServerStub(int status) {

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactoryTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactoryTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
+
 class JavaNetHttpPollingClientFactoryTest {
 
     private JavaNetHttpPollingClientFactory factory;
@@ -23,7 +25,8 @@ class JavaNetHttpPollingClientFactoryTest {
         assertThat(
             factory.createPollClient(
                 HttpLookupConfig.builder().build(),
-                (DeserializationSchema<RowData>) mock(DeserializationSchema.class))
+                (DeserializationSchema<RowData>) mock(DeserializationSchema.class),
+                new GenericGetQueryCreator())
         ).isInstanceOf(JavaNetHttpPollingClient.class);
     }
 }

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
@@ -30,8 +30,10 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.getindata.connectors.http.LookupArg;
 import com.getindata.connectors.http.internal.HttpsConnectionTestBase;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
 import static com.getindata.connectors.http.TestHelper.readTestFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -260,7 +262,8 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
                 .createDecodingFormat(dynamicTableFactoryContext, new Configuration())
                 .createRuntimeDecoder(dynamicTableSourceContext, physicalDataType);
 
-        return pollingClientFactory.createPollClient(lookupConfig, schemaDecoder);
+        return pollingClientFactory
+            .createPollClient(lookupConfig, schemaDecoder, new GenericGetQueryCreator());
     }
 
     private void setupServerStub() {

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import static com.getindata.connectors.http.TestHelper.assertPropertyArray;
 
@@ -40,6 +41,7 @@ public class JavaNetHttpPollingClientTest {
             httpClient,
             decoder,
             HttpLookupConfig.builder().build(),
+            new GenericGetQueryCreator(),
             headerPreprocessor
         );
         assertThat(client.getHeadersAndValues()).isEmpty();
@@ -74,6 +76,7 @@ public class JavaNetHttpPollingClientTest {
             httpClient,
             decoder,
             lookupConfig,
+            new GenericGetQueryCreator(),
             headerPreprocessor
         );
 

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorTest.java
@@ -1,0 +1,33 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.getindata.connectors.http.LookupArg;
+
+public class ElasticSearchLiteQueryCreatorTest {
+    static Stream<Arguments> queryArguments() {
+        return Stream.of(
+            Arguments.of(List.of(), ""),
+            Arguments.of(List.of(new LookupArg("key1", "val1")), "q=key1:%22val1%22"),
+            Arguments.of(List.of(
+                new LookupArg("key1", "val1"),
+                new LookupArg("key2", "val2"),
+                new LookupArg("key3", "3")
+            ), "q=key1:%22val1%22%20AND%20key2:%22val2%22%20AND%20key3:%223%22")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryArguments")
+    public void testGenericGetQueryCreation(List<LookupArg> args, String expectedQuery) {
+        var queryCreator = new ElasticSearchLiteQueryCreator();
+        var createdQuery = queryCreator.createLookupQuery(args);
+        assertThat(createdQuery).isEqualTo(expectedQuery);
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreatorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreatorTest.java
@@ -1,0 +1,33 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.getindata.connectors.http.LookupArg;
+
+public class GenericGetQueryCreatorTest {
+    static Stream<Arguments> queryArguments() {
+        return Stream.of(
+            Arguments.of(List.of(), ""),
+            Arguments.of(List.of(new LookupArg("key1", "val1")), "key1=val1"),
+            Arguments.of(List.of(
+                new LookupArg("key1", "val1"),
+                new LookupArg("key2", "val2"),
+                new LookupArg("key3", "3")
+            ), "key1=val1&key2=val2&key3=3")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryArguments")
+    public void testGenericGetQueryCreation(List<LookupArg> args, String expectedQuery) {
+        var queryCreator = new GenericGetQueryCreator();
+        var createdQuery = queryCreator.createLookupQuery(args);
+        assertThat(createdQuery).isEqualTo(expectedQuery);
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/utils/uri/URIBuilderTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/utils/uri/URIBuilderTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.getindata.connectors.http.internal.table.lookup.LookupArg;
+import com.getindata.connectors.http.LookupArg;
 
 class URIBuilderTest {
 


### PR DESCRIPTION
#### Description

- Add [LookupQueryCreator](src/main/java/com/getindata/connectors/http/LookupQueryCreator.java) and [LookupQueryCreatorFactory](src/main/java/com/getindata/connectors/http/LookupQueryCreatorFactory.java) interfaces (along with a "default" [GenericGetQueryCreator](src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java) implementation) for customization of queries prepared by Lookup Source for its HTTP requests.
- Add [ElasticSearchLiteQueryCreator](src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreator.java) that prepares [`q` parameter query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-api-query-params-q) using Lucene query string syntax (in first versions of ElasticSearch called [Search _Lite_](https://www.elastic.co/guide/en/elasticsearch/guide/current/search-lite.html)).

##### PR Checklist
- [X] Tests added
- [X] [Changelog](CHANGELOG.md) updated 
