### PR TITLE
ESP-263 - Adding suport for POST REST method to http Lookup Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+- Add support for other REST methods like PUT and POST to lookup source connector. The request method can be set using
+  new optional lookup-source property `lookup-method`. If property is not specified in table DDL, GET method will be used for
+  lookup queries.
+
 ## [0.5.0] - 2022-09-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,11 +83,21 @@ SELECT o.id, o.id2, c.msg, c.uuid, c.isActive, c.balance FROM Orders AS o
 JOIN Customers FOR SYSTEM_TIME AS OF o.proc_time AS c ON o.id = c.id AND o.id2 = c.id2
 ```
 
-The columns and their values used for JOIN `ON` condition will be used as HTTP get parameters where the column name will be used as a request parameter name. 
+The columns and their values used for JOIN `ON` condition will be used as HTTP GET parameters where the column name will be used as a request parameter name. 
+
 For Example: 
 ``
 http://localhost:8080/client/service?id=1&uuid=2
 ``
+
+Or for REST POST method they will be converted to Json and used as request body. In this case, json request body will look like this:
+```json
+{
+    "id": "1",
+    "uuid": "2"
+}
+```
+
 #### Http headers
 It is possible to set HTTP headers that will be added to HTTP request send by lookup source connector.
 Headers are defined via property key `gid.connector.http.source.lookup.header.HEADER_NAME = header value` for example:
@@ -256,6 +266,7 @@ If the used value starts from prefix `Basic `, it will be used as header value a
 | format                                                  | required | Flink's format name that should be used to decode REST response, Use `json` for a typical REST endpoint.                                             |
 | url                                                     | required | The base URL that should be use for GET requests. For example _http://localhost:8080/client_                                                         |
 | asyncPolling                                            | optional | true/false - determines whether Async Pooling should be used. Mechanism is based on Flink's Async I/O.                                               |
+| lookup-method                                           | optional | GET/POST/PUT (and any other) - determines what REST method should be used for lookup REST query. If not specified, `GET` method will be used.        |
 | gid.connector.http.lookup.error.code                    | optional | List of HTTP status codes that should be treated as errors by HTTP Source, separated with comma.                                                     |
 | gid.connector.http.lookup.error.code.exclude            | optional | List of HTTP status codes that should be excluded from the `gid.connector.http.lookup.error.code` list, separated with comma.                        |
 | gid.connector.http.security.cert.server                 | optional | Path to trusted HTTP server certificate that should be add to connectors key store. More than one path can be specified using `,` as path delimiter. |

--- a/src/main/java/com/getindata/connectors/http/LookupQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/LookupQueryCreator.java
@@ -11,6 +11,7 @@ import java.util.List;
  * {@link LookupQueryCreatorFactory}.
  */
 public interface LookupQueryCreator extends Serializable {
+
     /**
      * Create a lookup query (like the query appended to path in GET request)
      * out of the provided arguments.

--- a/src/main/java/com/getindata/connectors/http/LookupQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/LookupQueryCreatorFactory.java
@@ -30,6 +30,7 @@ import com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSource
  * }</pre>
  */
 public interface LookupQueryCreatorFactory extends Factory {
+
     /**
      * @return {@link LookupQueryCreator} custom lookup query creator instance
      */

--- a/src/main/java/com/getindata/connectors/http/internal/PollingClientFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/PollingClientFactory.java
@@ -4,14 +4,12 @@ import java.io.Serializable;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 
-import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.table.lookup.HttpLookupConfig;
 
 public interface PollingClientFactory<OUT> extends Serializable {
 
     PollingClient<OUT> createPollClient(
         HttpLookupConfig options,
-        DeserializationSchema<OUT> schemaDecoder,
-        LookupQueryCreator lookupQueryCreator
+        DeserializationSchema<OUT> schemaDecoder
     );
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/BodyBasedRequestFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/BodyBasedRequestFactory.java
@@ -1,0 +1,54 @@
+package com.getindata.connectors.http.internal.table.lookup;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpRequest.Builder;
+import java.time.Duration;
+
+import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
+import com.getindata.connectors.http.internal.utils.uri.URIBuilder;
+
+/**
+ * Implementation of {@link HttpRequestFactory} for REST calls that sends their parameters using
+ * request body.
+ */
+public class BodyBasedRequestFactory extends RequestFactoryBase {
+
+    private final String methodName;
+
+    public BodyBasedRequestFactory(
+            String methodName,
+            LookupQueryCreator lookupQueryCreator,
+            HeaderPreprocessor headerPreprocessor,
+            HttpLookupConfig options) {
+
+        super(lookupQueryCreator, headerPreprocessor, options);
+        this.methodName = methodName.toUpperCase();
+    }
+
+    /**
+     * Method for preparing {@link HttpRequest.Builder} for REST request that sends their parameters
+     * in request body, for example PUT or POST methods
+     *
+     * @param lookupQuery lookup query used for request body.
+     * @return {@link HttpRequest.Builder} for given lookupQuery.
+     */
+    @Override
+    protected Builder setUpRequestMethod(String lookupQuery) {
+        return HttpRequest.newBuilder()
+            .uri(constructGetUri())
+            .method(methodName, BodyPublishers.ofString(lookupQuery))
+            .timeout(Duration.ofMinutes(2));
+    }
+
+    private URI constructGetUri() {
+        try {
+            return new URIBuilder(baseUrl).build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/GetRequestFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/GetRequestFactory.java
@@ -1,0 +1,50 @@
+package com.getindata.connectors.http.internal.table.lookup;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
+import java.time.Duration;
+
+import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
+import com.getindata.connectors.http.internal.utils.uri.URIBuilder;
+
+/**
+ * Implementation of {@link HttpRequestFactory} for GET REST calls.
+ */
+public class GetRequestFactory extends RequestFactoryBase {
+
+    public GetRequestFactory(
+            LookupQueryCreator lookupQueryCreator,
+            HeaderPreprocessor headerPreprocessor,
+            HttpLookupConfig options) {
+
+        super(lookupQueryCreator, headerPreprocessor, options);
+    }
+
+    /**
+     * Method for preparing {@link HttpRequest.Builder} for REST GET request, where lookupQuery
+     * is used as query parameters for example:
+     * <pre>
+     *     http:localhost:8080/service?id=1
+     * </pre>
+     * @param lookupQuery lookup query used for request query parameters.
+     * @return {@link HttpRequest.Builder} for given GET lookupQuery
+     */
+    @Override
+    protected Builder setUpRequestMethod(String lookupQuery) {
+        return HttpRequest.newBuilder()
+            .uri(constructGetUri(lookupQuery))
+            .GET()
+            .timeout(Duration.ofMinutes(2));
+    }
+
+    private URI constructGetUri(String lookupQuery) {
+        try {
+            return new URIBuilder(baseUrl + "?" + lookupQuery).build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupConnectorOptions.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupConnectorOptions.java
@@ -3,7 +3,6 @@ package com.getindata.connectors.http.internal.table.lookup;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
-import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreatorFactory;
 import static com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants.SOURCE_LOOKUP_QUERY_CREATOR_IDENTIFIER;
 
 public class HttpLookupConnectorOptions {
@@ -26,8 +25,14 @@ public class HttpLookupConnectorOptions {
             .defaultValue(false)
             .withDescription("Whether to use Sync and Async polling mechanism");
 
+    public static final ConfigOption<String> LOOKUP_METHOD =
+        ConfigOptions.key("lookup-method")
+            .stringType()
+            .defaultValue("GET")
+            .withDescription("Method used for REST executed by lookup connector.");
+
     public static final ConfigOption<String> LOOKUP_QUERY_CREATOR_IDENTIFIER =
         ConfigOptions.key(SOURCE_LOOKUP_QUERY_CREATOR_IDENTIFIER)
             .stringType()
-            .defaultValue(GenericGetQueryCreatorFactory.IDENTIFIER);
+            .noDefaultValue();
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
@@ -15,7 +15,6 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
-import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 import com.getindata.connectors.http.internal.table.lookup.HttpTableLookupFunction.ColumnData;
 
@@ -31,8 +30,6 @@ public class HttpLookupTableSource
     private final HttpLookupConfig lookupConfig;
 
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
-
-    private final LookupQueryCreator lookupQueryCreator;
 
     @Override
     public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
@@ -53,8 +50,7 @@ public class HttpLookupTableSource
             physicalRowDataType,
             pollingClientFactory,
             lookupConfig,
-            decodingFormat,
-            lookupQueryCreator
+            decodingFormat
         );
     }
 
@@ -84,7 +80,6 @@ public class HttpLookupTableSource
                 .pollingClientFactory(pollingClientFactory)
                 .schemaDecoder(schemaDecoder)
                 .columnData(columnData)
-                .lookupQueryCreator(lookupQueryCreator)
                 .options(lookupConfig)
                 .build();
 

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpRequestFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpRequestFactory.java
@@ -1,0 +1,21 @@
+package com.getindata.connectors.http.internal.table.lookup;
+
+import java.io.Serializable;
+import java.net.http.HttpRequest;
+import java.util.List;
+
+import com.getindata.connectors.http.LookupArg;
+
+/**
+ * Factory for creating {@link HttpRequest} objects for Rest clients.
+ */
+public interface HttpRequestFactory extends Serializable {
+
+    /**
+     * Creates {@link HttpRequest} from given List of {@link LookupArg} objects.
+     *
+     * @param params {@link LookupArg} objects used for building http request.
+     * @return {@link HttpRequest} created from {@link LookupArg}
+     */
+    HttpRequest buildLookupRequest(List<LookupArg> params);
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpTableLookupFunction.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpTableLookupFunction.java
@@ -20,7 +20,6 @@ import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.TableFunction;
 
 import com.getindata.connectors.http.LookupArg;
-import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.PollingClient;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 
@@ -30,8 +29,6 @@ public class HttpTableLookupFunction extends TableFunction<RowData> {
     private final PollingClientFactory<RowData> pollingClientFactory;
 
     private final DeserializationSchema<RowData> schemaDecoder;
-
-    private final LookupQueryCreator lookupQueryCreator;
 
     @Getter
     private final ColumnData columnData;
@@ -48,14 +45,12 @@ public class HttpTableLookupFunction extends TableFunction<RowData> {
         PollingClientFactory<RowData> pollingClientFactory,
         DeserializationSchema<RowData> schemaDecoder,
         ColumnData columnData,
-        HttpLookupConfig options,
-        LookupQueryCreator lookupQueryCreator) {
+        HttpLookupConfig options) {
 
         this.pollingClientFactory = pollingClientFactory;
         this.schemaDecoder = schemaDecoder;
         this.columnData = columnData;
         this.options = options;
-        this.lookupQueryCreator = lookupQueryCreator;
     }
 
     @Override
@@ -63,7 +58,7 @@ public class HttpTableLookupFunction extends TableFunction<RowData> {
         super.open(context);
         this.localHttpCallCounter = new AtomicInteger(0);
         this.client = pollingClientFactory
-            .createPollClient(options, schemaDecoder, lookupQueryCreator);
+            .createPollClient(options, schemaDecoder);
 
         context
             .getMetricGroup()

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactory.java
@@ -5,32 +5,29 @@ import java.net.http.HttpClient;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.data.RowData;
 
-import com.getindata.connectors.http.LookupQueryCreator;
-import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.PollingClientFactory;
-import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
 
 public class JavaNetHttpPollingClientFactory implements PollingClientFactory<RowData> {
 
+    private final HttpRequestFactory requestFactory;
+
+    public JavaNetHttpPollingClientFactory(HttpRequestFactory requestFactory) {
+        this.requestFactory = requestFactory;
+    }
+
     @Override
     public JavaNetHttpPollingClient createPollClient(
-        HttpLookupConfig options,
-        DeserializationSchema<RowData> schemaDecoder,
-        LookupQueryCreator lookupQueryCreator) {
+            HttpLookupConfig options,
+            DeserializationSchema<RowData> schemaDecoder) {
 
         HttpClient httpClient = JavaNetHttpClientFactory.createClient(options.getProperties());
-
-        // TODO Consider this to be injected as method argument or factory field
-        //  so user could set this using API.
-        HeaderPreprocessor headerPreprocessor = HttpHeaderUtils.createDefaultHeaderPreprocessor();
 
         return new JavaNetHttpPollingClient(
             httpClient,
             schemaDecoder,
             options,
-            lookupQueryCreator,
-            headerPreprocessor
+            requestFactory
         );
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/RequestFactoryBase.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/RequestFactoryBase.java
@@ -1,0 +1,75 @@
+package com.getindata.connectors.http.internal.table.lookup;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import com.getindata.connectors.http.LookupArg;
+import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
+import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
+
+/**
+ * Base class for {@link HttpRequest} factories.
+ */
+public abstract class RequestFactoryBase implements HttpRequestFactory {
+
+    /**
+     * Base url used for {@link HttpRequest} for example "http://localhost:8080"
+     */
+    protected final String baseUrl;
+
+    protected final LookupQueryCreator lookupQueryCreator;
+
+    /**
+     * HTTP headers that should be used for {@link HttpRequest} created by factory.
+     */
+    private final String[] headersAndValues;
+
+    public RequestFactoryBase(
+            LookupQueryCreator lookupQueryCreator,
+            HeaderPreprocessor headerPreprocessor,
+            HttpLookupConfig options) {
+
+        this.baseUrl = options.getUrl();
+        this.lookupQueryCreator = lookupQueryCreator;
+
+        var headerMap = HttpHeaderUtils
+            .prepareHeaderMap(
+                HttpConnectorConfigConstants.LOOKUP_SOURCE_HEADER_PREFIX,
+                options.getProperties(),
+                headerPreprocessor
+            );
+
+        this.headersAndValues = HttpHeaderUtils.toHeaderAndValueArray(headerMap);
+    }
+
+    @Override
+    public HttpRequest buildLookupRequest(List<LookupArg> params) {
+
+        var lookupQuery = lookupQueryCreator.createLookupQuery(params);
+        Builder requestBuilder = setUpRequestMethod(lookupQuery);
+
+        if (headersAndValues.length != 0) {
+            requestBuilder.headers(headersAndValues);
+        }
+
+        return requestBuilder.build();
+    }
+
+    /**
+     * Method for preparing {@link HttpRequest.Builder} for concrete REST method.
+     * @param lookupQuery lookup query used for request query parameters or body.
+     * @return {@link HttpRequest.Builder} for given lookupQuery.
+     */
+    protected abstract Builder setUpRequestMethod(String lookupQuery);
+
+    @VisibleForTesting
+    String[] getHeadersAndValues() {
+        return Arrays.copyOf(headersAndValues, headersAndValues.length);
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorFactory.java
@@ -11,6 +11,7 @@ import com.getindata.connectors.http.LookupQueryCreatorFactory;
  * Factory for creating {@link ElasticSearchLiteQueryCreator}.
  */
 public class ElasticSearchLiteQueryCreatorFactory implements LookupQueryCreatorFactory {
+
     public static final String IDENTIFIER = "elasticsearch-lite";
 
     @Override

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java
@@ -14,6 +14,7 @@ import com.getindata.connectors.http.internal.utils.uri.URLEncodedUtils;
  * <code>joinColumn1=value1&amp;joinColumn2=value2&amp;...</code> to the URI of the endpoint.
  */
 public class GenericGetQueryCreator implements LookupQueryCreator {
+
     @Override
     public String createLookupQuery(List<LookupArg> params) {
         return URLEncodedUtils.format(

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreator.java
@@ -1,0 +1,49 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.util.List;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+
+import com.getindata.connectors.http.LookupArg;
+import com.getindata.connectors.http.LookupQueryCreator;
+
+/**
+ * A {@link LookupQueryCreator} that builds Json based body for REST requests, i.e. adds
+ */
+public class GenericJsonQueryCreator implements LookupQueryCreator {
+
+    private final ObjectMapper objectMapper;
+
+    public GenericJsonQueryCreator() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Creates a Jason string from given List of {@link LookupArg}.
+     * The list is converted to a Json objects containing pairs of {@code LookupArg.getArgName()}
+     * and {@code LookupArg.getArgValue()} from params parameter.
+     * <p>
+     * A two element array of {@link LookupArg} objects, were first element contains a pair of
+     * {@code "id" -> "1"} and second element contains a pair of {@code "uuid" -> "2"}
+     * will be converted to below Json:
+     * <pre>
+     *     {
+     *         "id": "1",
+     *         "uuid": "2"
+     *     }
+     * </pre>
+     *
+     * @param params the list of {@link LookupArg} containing request parameters that will be
+     *               converted to Json string.
+     * @return Json string created from param argument.
+     */
+    @Override
+    public String createLookupQuery(List<LookupArg> params) {
+        ObjectNode root = this.objectMapper.createObjectNode();
+        for (LookupArg arg : params) {
+            root.put(arg.getArgName(), arg.getArgValue());
+        }
+        return root.toString();
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorFactory.java
@@ -8,15 +8,15 @@ import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.LookupQueryCreatorFactory;
 
 /**
- * Factory for creating {@link GenericGetQueryCreator}.
+ * Factory for creating {@link GenericJsonQueryCreatorFactory}.
  */
-public class GenericGetQueryCreatorFactory implements LookupQueryCreatorFactory {
+public class GenericJsonQueryCreatorFactory implements LookupQueryCreatorFactory {
 
-    public static final String IDENTIFIER = "generic-get-query";
+    public static final String IDENTIFIER = "generic-json-query";
 
     @Override
     public LookupQueryCreator createLookupQueryCreator() {
-        return new GenericGetQueryCreator();
+        return new GenericJsonQueryCreator();
     }
 
     @Override

--- a/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,5 +1,6 @@
 com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSourceFactory
 com.getindata.connectors.http.internal.table.lookup.querycreators.ElasticSearchLiteQueryCreatorFactory
 com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreatorFactory
+com.getindata.connectors.http.internal.table.lookup.querycreators.GenericJsonQueryCreatorFactory
 com.getindata.connectors.http.internal.table.sink.HttpDynamicTableSinkFactory
 com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallbackFactory

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/HttpRowDataLookupFunctionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/HttpRowDataLookupFunctionTest.java
@@ -21,11 +21,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.getindata.connectors.http.LookupArg;
-import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.internal.PollingClient;
 import com.getindata.connectors.http.internal.PollingClientFactory;
 import com.getindata.connectors.http.internal.table.lookup.HttpTableLookupFunction.ColumnData;
-import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
 
 @ExtendWith(MockitoExtension.class)
 class HttpRowDataLookupFunctionTest {
@@ -53,7 +51,6 @@ class HttpRowDataLookupFunctionTest {
     @BeforeEach
     void setUp() throws Exception {
         HttpLookupConfig lookupConfig = HttpLookupConfig.builder().build();
-        LookupQueryCreator lookupQueryCreator = new GenericGetQueryCreator();
 
         ColumnData columnData =
             ColumnData.builder()
@@ -61,7 +58,7 @@ class HttpRowDataLookupFunctionTest {
                 .build();
 
         when(functionContext.getMetricGroup()).thenReturn(mock(MetricGroup.class));
-        when(pollingClientFactory.createPollClient(lookupConfig, schemaDecoder, lookupQueryCreator))
+        when(pollingClientFactory.createPollClient(lookupConfig, schemaDecoder))
             .thenReturn(client);
 
         lookupFunction = HttpTableLookupFunction.builder()
@@ -69,7 +66,6 @@ class HttpRowDataLookupFunctionTest {
             .schemaDecoder(schemaDecoder)
             .columnData(columnData)
             .options(lookupConfig)
-            .lookupQueryCreator(lookupQueryCreator)
             .build();
 
         lookupFunction.open(functionContext);

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactoryTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientFactoryTest.java
@@ -7,15 +7,13 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
-
 class JavaNetHttpPollingClientFactoryTest {
 
     private JavaNetHttpPollingClientFactory factory;
 
     @BeforeEach
     public void setUp() {
-        factory = new JavaNetHttpPollingClientFactory();
+        factory = new JavaNetHttpPollingClientFactory(mock(GetRequestFactory.class));
     }
 
     @Test
@@ -25,8 +23,7 @@ class JavaNetHttpPollingClientFactoryTest {
         assertThat(
             factory.createPollClient(
                 HttpLookupConfig.builder().build(),
-                (DeserializationSchema<RowData>) mock(DeserializationSchema.class),
-                new GenericGetQueryCreator())
+                (DeserializationSchema<RowData>) mock(DeserializationSchema.class))
         ).isInstanceOf(JavaNetHttpPollingClient.class);
     }
 }

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientTest.java
@@ -29,9 +29,12 @@ public class JavaNetHttpPollingClientTest {
 
     private HeaderPreprocessor headerPreprocessor;
 
+    private HttpLookupConfig options;
+
     @BeforeEach
     public void setUp() {
         this.headerPreprocessor = HttpHeaderUtils.createDefaultHeaderPreprocessor();
+        this.options = HttpLookupConfig.builder().build();
     }
 
     @Test
@@ -40,11 +43,13 @@ public class JavaNetHttpPollingClientTest {
         JavaNetHttpPollingClient client = new JavaNetHttpPollingClient(
             httpClient,
             decoder,
-            HttpLookupConfig.builder().build(),
-            new GenericGetQueryCreator(),
-            headerPreprocessor
+            options,
+            new GetRequestFactory(new GenericGetQueryCreator(), headerPreprocessor, options)
         );
-        assertThat(client.getHeadersAndValues()).isEmpty();
+
+        assertThat(
+            ((GetRequestFactory) client.getRequestFactory()).getHeadersAndValues())
+            .isEmpty();
     }
 
     @Test
@@ -76,11 +81,11 @@ public class JavaNetHttpPollingClientTest {
             httpClient,
             decoder,
             lookupConfig,
-            new GenericGetQueryCreator(),
-            headerPreprocessor
+            new GetRequestFactory(new GenericGetQueryCreator(), headerPreprocessor, lookupConfig)
         );
 
-        String[] headersAndValues = client.getHeadersAndValues();
+        String[] headersAndValues =
+            ((GetRequestFactory) client.getRequestFactory()).getHeadersAndValues();
         assertThat(headersAndValues).hasSize(6);
 
         // THEN


### PR DESCRIPTION
#### Description

Adding support for using POST REST request method to http Lookup Source. In fact any method HTTP method can be used.
Request method can be set by using DDL option `lookup-method` with value "GET", "POST" etc. If option is not defined, then GET method will be used.

For request body methods like POST/PUT lookup parameters will be converted to json and used as request body.
For default configuration the new `LookupQueryCreator` interface implementation - `GenericJsonQueryCreator` will be used to convert Join arruments to json, for example

```
{
        "id": "1",
        "uuid": "2"
}
```

User can define custom `LookupQueryCreator` and use it for its table definition via `gid.connector.http.source.lookup.query-creator` property

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
