### PR TITLE
[HTTP-43] - Remove Encoding format from HttpLookupTableSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Removed
+-   Removed unused reference to EncodingFormat from HttpLookupTableSource
+
 ## [0.8.0] - 2022-12-06
 
 ### Added

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
@@ -5,11 +5,9 @@ import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.connector.format.DecodingFormat;
-import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.source.AsyncTableFunctionProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
@@ -42,18 +40,15 @@ public class HttpLookupTableSource
 
     private final HttpLookupConfig lookupConfig;
 
-    private final EncodingFormat<SerializationSchema<RowData>> encodingFormat;
-
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
 
-    public HttpLookupTableSource(DataType physicalRowDataType,
-        HttpLookupConfig lookupConfig,
-        EncodingFormat<SerializationSchema<RowData>> encodingFormat,
-        DecodingFormat<DeserializationSchema<RowData>> decodingFormat) {
+    public HttpLookupTableSource(
+            DataType physicalRowDataType,
+            HttpLookupConfig lookupConfig,
+            DecodingFormat<DeserializationSchema<RowData>> decodingFormat) {
 
         this.physicalRowDataType = physicalRowDataType;
         this.lookupConfig = lookupConfig;
-        this.encodingFormat = encodingFormat;
         this.decodingFormat = decodingFormat;
     }
 
@@ -109,7 +104,6 @@ public class HttpLookupTableSource
         return new HttpLookupTableSource(
             physicalRowDataType,
             lookupConfig,
-            encodingFormat,
             decodingFormat
         );
     }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSourceFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSourceFactory.java
@@ -7,7 +7,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.DataTypes;
@@ -15,13 +14,11 @@ import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.format.DecodingFormat;
-import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.table.factories.SerializationFormatFactory;
 import org.apache.flink.table.types.DataType;
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.types.utils.DataTypeUtils.removeTimeAttribute;
@@ -58,11 +55,6 @@ public class HttpLookupTableSourceFactory implements DynamicTableSourceFactory {
             LOOKUP_REQUEST_FORMAT.key()
         );
 
-        EncodingFormat<SerializationSchema<RowData>> encodingFormat =
-            helper.discoverEncodingFormat(SerializationFormatFactory.class,
-                HttpLookupConnectorOptions.LOOKUP_REQUEST_FORMAT
-            );
-
         DecodingFormat<DeserializationSchema<RowData>> decodingFormat =
             helper.discoverDecodingFormat(
                 DeserializationFormatFactory.class,
@@ -79,7 +71,6 @@ public class HttpLookupTableSourceFactory implements DynamicTableSourceFactory {
         return new HttpLookupTableSource(
             physicalRowDataType,
             lookupConfig,
-            encodingFormat,
             decodingFormat
         );
     }


### PR DESCRIPTION
#### Description

The 'HttpLookupTableSource' has unused reference to Encoding format. It is not needed, since concrete type of encoding format should be created by 'LookupQueryCreatorFactory' implementation.

This PR removes this reference.

Resolves https://github.com/getindata/flink-http-connector/issues/43

##### PR Checklist
- [ ] Tests added (N/A)
- [x] [Changelog](CHANGELOG.md) updated 
