### PR TITLE
[HTTP-37] - Add support for Flink 1.16.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flink: [ "1.15.0", "1.15.3", "1.16.1" ]
     steps:
       - uses: actions/checkout@v3
 
@@ -26,23 +29,24 @@ jobs:
           distribution: 'adopt'
           cache: maven
 
-      - name: Build
-        run: mvn $MAVEN_CLI_OPTS $JAVA_ADDITIONAL_OPTS compile
+      - name: Build for Flink ${{ matrix.flink }}
+        run: mvn $MAVEN_CLI_OPTS $JAVA_ADDITIONAL_OPTS -Dflink.version=${{ matrix.flink }} compile
 
-      - name: Tests
+      - name: Tests for Flink ${{ matrix.flink }}
         run: |
-          mvn $MAVEN_CLI_OPTS $JAVA_ADDITIONAL_OPTS test integration-test
+          mvn $MAVEN_CLI_OPTS $JAVA_ADDITIONAL_OPTS -Dflink.version=${{ matrix.flink }} test integration-test
           cat target/site/jacoco/index.html | grep -o 'Total[^%]*%'
 
       - name: Test JavaDoc
         run: mvn $MAVEN_CLI_OPTS $JAVA_ADDITIONAL_OPTS javadoc:javadoc
+        if: startsWith(matrix.flink, '1.15.0')
 
       - name: Add coverage to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.2
-        if: github.event_name == 'pull_request'
         with:
           paths: ${{ github.workspace }}/target/site/jacoco/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60
+        if: startsWith(matrix.flink, '1.15.0')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+-   Add support for Flink 1.16.
+-   Add [SchemaLifecycleAwareElementConverter](src/main/java/com/getindata/connectors/http/SchemaLifecycleAwareElementConverter.java) that can be used for createing
+    schema lifecycle aware Element converters for Http Sink.
 
 ## [0.8.1] - 2022-12-22
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ under the License.
 
     <!-- IMPORTANT: If you update Flink, remember to update link to its docs in maven-javadoc-plugin <links>
          section, omitting the patch part (so for 1.15.0 use 1.15). -->
-    <flink.version>1.15.0</flink.version>
+    <flink.version>[1.15.0,)</flink.version>
 
     <target.java.version>11</target.java.version>
     <scala.binary.version>2.12</scala.binary.version>

--- a/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
+++ b/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
@@ -114,10 +114,25 @@ public class HttpSinkBuilder<InputT> extends
     /**
      * @param elementConverter the {@link ElementConverter} to be used for the sink
      * @return {@link HttpSinkBuilder} itself
+     * @deprecated Converters set by this method might not work properly for Flink 1.16+. Use {@link
+     * #setElementConverter(SchemaLifecycleAwareElementConverter)} instead.
      */
+    @Deprecated
     @PublicEvolving
     public HttpSinkBuilder<InputT> setElementConverter(
         ElementConverter<InputT, HttpSinkRequestEntry> elementConverter) {
+        this.elementConverter = elementConverter;
+        return this;
+    }
+
+    /**
+     * @param elementConverter the {@link SchemaLifecycleAwareElementConverter} to be used for the
+     *                         sink
+     * @return {@link HttpSinkBuilder} itself
+     */
+    @PublicEvolving
+    public HttpSinkBuilder<InputT> setElementConverter(
+        SchemaLifecycleAwareElementConverter<InputT, HttpSinkRequestEntry> elementConverter) {
         this.elementConverter = elementConverter;
         return this;
     }

--- a/src/main/java/com/getindata/connectors/http/SchemaLifecycleAwareElementConverter.java
+++ b/src/main/java/com/getindata/connectors/http/SchemaLifecycleAwareElementConverter.java
@@ -1,0 +1,34 @@
+package com.getindata.connectors.http;
+
+import org.apache.flink.api.common.serialization.SerializationSchema.InitializationContext;
+import org.apache.flink.api.connector.sink2.Sink.InitContext;
+import org.apache.flink.connector.base.sink.writer.ElementConverter;
+
+/**
+ * An enhancement for Flink's {@link ElementConverter} that expose {@link #open(InitContext)} method
+ * that will be called by HTTP connect code to ensure that element converter is initialized
+ * properly. This is required for cases when Flink's SerializationSchema and DeserializationSchema
+ * objects like JsonRowDataSerializationSchema are used.
+ * <p>
+ * This interface specifies the mapping between elements of a stream to request entries that can be
+ * sent to the destination. The mapping is provided by the end-user of a sink, not the sink
+ * creator.
+ *
+ * <p>The request entries contain all relevant information required to create and sent the actual
+ * request. Eg, for Kinesis Data Streams, the request entry includes the payload and the partition
+ * key.
+ */
+public interface SchemaLifecycleAwareElementConverter<InputT, RequestEntryT>
+    extends ElementConverter<InputT, RequestEntryT> {
+
+    /**
+     * Initialization element converter for the schema.
+     *
+     * <p>The provided {@link InitializationContext} can be used to access additional features such
+     * as e.g. registering user metrics.
+     *
+     * @param context Contextual information that can be used during initialization.
+     */
+    void open(InitContext context);
+
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/SerializationSchemaElementConverter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/SerializationSchemaElementConverter.java
@@ -1,0 +1,47 @@
+package com.getindata.connectors.http.internal.table;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.connector.sink2.Sink.InitContext;
+import org.apache.flink.api.connector.sink2.SinkWriter.Context;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.getindata.connectors.http.SchemaLifecycleAwareElementConverter;
+import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+
+public class SerializationSchemaElementConverter
+    implements SchemaLifecycleAwareElementConverter<RowData, HttpSinkRequestEntry> {
+
+    private final String insertMethod;
+
+    private final SerializationSchema<RowData> serializationSchema;
+
+    private boolean schemaOpened = false;
+
+    public SerializationSchemaElementConverter(
+        String insertMethod,
+        SerializationSchema<RowData> serializationSchema) {
+
+        this.insertMethod = insertMethod;
+        this.serializationSchema = serializationSchema;
+    }
+
+    @Override
+    public void open(InitContext context) {
+        if (!schemaOpened) {
+            try {
+                serializationSchema.open(context.asSerializationSchemaInitializationContext());
+                schemaOpened = true;
+            } catch (Exception e) {
+                throw new FlinkRuntimeException("Failed to initialize serialization schema.", e);
+            }
+        }
+    }
+
+    @Override
+    public HttpSinkRequestEntry apply(RowData rowData, Context context) {
+        return new HttpSinkRequestEntry(
+            insertMethod,
+            serializationSchema.serialize(rowData));
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpTableLookupFunction.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpTableLookupFunction.java
@@ -15,6 +15,7 @@ import org.apache.flink.table.functions.TableFunction;
 
 import com.getindata.connectors.http.internal.PollingClient;
 import com.getindata.connectors.http.internal.PollingClientFactory;
+import com.getindata.connectors.http.internal.utils.SerializationSchemaUtils;
 
 @Slf4j
 public class HttpTableLookupFunction extends TableFunction<RowData> {
@@ -50,6 +51,11 @@ public class HttpTableLookupFunction extends TableFunction<RowData> {
     @Override
     public void open(FunctionContext context) throws Exception {
         super.open(context);
+
+        this.responseSchemaDecoder.open(
+            SerializationSchemaUtils
+                .createDeserializationInitContext(HttpTableLookupFunction.class));
+
         this.localHttpCallCounter = new AtomicInteger(0);
         this.client = pollingClientFactory
             .createPollClient(options, responseSchemaDecoder);

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
@@ -22,6 +22,7 @@ import com.getindata.connectors.http.HttpSink;
 import com.getindata.connectors.http.HttpSinkBuilder;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 import com.getindata.connectors.http.internal.sink.httpclient.JavaNetSinkHttpClient;
+import com.getindata.connectors.http.internal.table.SerializationSchemaElementConverter;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.INSERT_METHOD;
 import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.URL;
@@ -128,10 +129,8 @@ public class HttpDynamicSink extends AsyncDynamicTableSink<HttpSinkRequestEntry>
             .setHttpPostRequestCallback(httpPostRequestCallback)
             // In future header preprocessor could be set via custom factory
             .setHttpHeaderPreprocessor(HttpHeaderUtils.createDefaultHeaderPreprocessor())
-            .setElementConverter((rowData, _context) -> new HttpSinkRequestEntry(
-                insertMethod,
-                serializationSchema.serialize(rowData)
-            ))
+            .setElementConverter(
+                new SerializationSchemaElementConverter(insertMethod, serializationSchema))
             .setProperties(properties);
         addAsyncOptionsToSinkBuilder(builder);
 

--- a/src/main/java/com/getindata/connectors/http/internal/utils/SerializationSchemaUtils.java
+++ b/src/main/java/com/getindata/connectors/http/internal/utils/SerializationSchemaUtils.java
@@ -1,0 +1,50 @@
+package com.getindata.connectors.http.internal.utils;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
+
+public final class SerializationSchemaUtils {
+
+    private SerializationSchemaUtils() {
+
+    }
+
+    public static <T> org.apache.flink.api.common.serialization.SerializationSchema
+            .InitializationContext createSerializationInitContext(Class<T> classForClassLoader) {
+
+        return new org.apache.flink.api.common.serialization.SerializationSchema
+                .InitializationContext() {
+
+            @Override
+            public MetricGroup getMetricGroup() {
+                return new UnregisteredMetricsGroup();
+            }
+
+            @Override
+            public UserCodeClassLoader getUserCodeClassLoader() {
+                return SimpleUserCodeClassLoader.create(classForClassLoader.getClassLoader());
+            }
+        };
+    }
+
+    public static <T> org.apache.flink.api.common.serialization.DeserializationSchema
+        .InitializationContext createDeserializationInitContext(Class<T> classForClassLoader) {
+
+        return new org.apache.flink.api.common.serialization.DeserializationSchema
+            .InitializationContext() {
+
+            @Override
+            public MetricGroup getMetricGroup() {
+                return new UnregisteredMetricsGroup();
+            }
+
+            @Override
+            public UserCodeClassLoader getUserCodeClassLoader() {
+                return SimpleUserCodeClassLoader.create(classForClassLoader.getClassLoader());
+            }
+        };
+    }
+
+}

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkWriterTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkWriterTest.java
@@ -13,6 +13,7 @@ import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,8 +43,12 @@ class HttpSinkWriterTest {
     @Mock
     private SinkHttpClient httpClient;
 
-    @Mock
+    // To work with Flink 1.15 and Flink 1.16
+    @Mock(lenient = true)
     private SinkWriterMetricGroup metricGroup;
+
+    @Mock
+    private OperatorIOMetricGroup operatorIOMetricGroup;
 
     @Mock
     private Counter errorCounter;
@@ -51,6 +56,7 @@ class HttpSinkWriterTest {
     @BeforeEach
     public void setUp() {
         when(metricGroup.getNumRecordsSendErrorsCounter()).thenReturn(errorCounter);
+        when(metricGroup.getIOMetricGroup()).thenReturn(operatorIOMetricGroup);
         when(context.metricGroup()).thenReturn(metricGroup);
 
         Collection<BufferedRequestState<HttpSinkRequestEntry>> stateBuffer = new ArrayList<>();

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientConnectionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientConnectionTest.java
@@ -49,6 +49,7 @@ import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstant
 import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
 import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericJsonQueryCreator;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
+import com.getindata.connectors.http.internal.utils.SerializationSchemaUtils;
 import static com.getindata.connectors.http.TestHelper.readTestFile;
 import static com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSourceFactory.row;
 
@@ -367,6 +368,14 @@ class JavaNetHttpPollingClientConnectionTest {
             new JsonFormatFactory()
                 .createDecodingFormat(dynamicTableFactoryContext, new Configuration())
                 .createRuntimeDecoder(dynamicTableSourceContext, physicalDataType);
+
+        try {
+            schemaDecoder.open(
+                SerializationSchemaUtils.createDeserializationInitContext(
+                    JavaNetHttpPollingClientConnectionTest.class));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to open schema decoder: " + e.getMessage(), e);
+        }
 
         JavaNetHttpPollingClientFactory pollingClientFactory =
             new JavaNetHttpPollingClientFactory(requestFactory);

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClientHttpsConnectionTest.java
@@ -36,6 +36,7 @@ import com.getindata.connectors.http.internal.HttpsConnectionTestBase;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
 import com.getindata.connectors.http.internal.table.lookup.querycreators.GenericGetQueryCreator;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
+import com.getindata.connectors.http.internal.utils.SerializationSchemaUtils;
 import static com.getindata.connectors.http.TestHelper.readTestFile;
 import static com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSourceFactory.row;
 
@@ -276,6 +277,14 @@ public class JavaNetHttpPollingClientHttpsConnectionTest extends HttpsConnection
             new JsonFormatFactory()
                 .createDecodingFormat(dynamicTableFactoryContext, new Configuration())
                 .createRuntimeDecoder(dynamicTableSourceContext, physicalDataType);
+
+        try {
+            schemaDecoder.open(
+                SerializationSchemaUtils.createDeserializationInitContext(
+                    JavaNetHttpPollingClientConnectionTest.class));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to open schema decoder: " + e.getMessage(), e);
+        }
 
         return pollingClientFactory.createPollClient(lookupConfig, schemaDecoder);
     }


### PR DESCRIPTION
#### Description
It was not possible to use HTTP connector with Flink 1.16. This PR allows to use HTTP connector with Flink 1.15 and 1.16. 
Additionally extra GitHub builds were added to make sure our connector can be used with different Flink versions.

#### Detailed description of the root cause and fix.
The https://issues.apache.org/jira/browse/FLINK-28807 introduced in Flink 1.16 changed the way how `SerializationSchema` and `DeserializationSchema` objects should be initialized. The change that impacted HTTP connector was change made in Flink's `JsonRowDataSerializationSchema`. Before FLINK-28807 `ObjectMapper` instance for `JsonRowDataSerializationSchema` was initialized as class field member, where in Flink 1.16 ObjecTMaper is initialized in `open` method which we did not call.

Proposed change simply ensure that `open` method will be called for every `SerializationSchema` and `DeserializationSchema`  schema used by connector.

Public API was changed but with backward compatibility, although `@Deprecated` annotation was added to one of the `SinkBuilder` methods. Also the new public interface `SchemaLifecycleAwareElementConverter` was added. This interface allows to create Flink's `ElementConverter` on which `open` method will be called. This method will be called by HTTP Sink builder ensuring that Schema Serialziation and Deserialization object will be initialized properly for Flink 1.16.

Resolves https://github.com/getindata/flink-http-connector/issues/37

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
