### PR TITLE
HTTP-42 Add support for Batch request submission in HTTP Sink.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -   Changed API for public HttpSink builder. The `setHttpPostRequestCallback` expects a `PostRequestCallback`
     of generic type [HttpRequest](src/main/java/com/getindata/connectors/http/internal/sink/httpclient/HttpRequest.java)
     instead `HttpSinkRequestEntry`.
--   Changed HTTP sink reqeust and response processing thread pool sizes from 16 to 1.
+-   Changed HTTP sink request and response processing thread pool sizes from 16 to 1.
 
 ## [0.9.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+-   Add support for batch request submission in HTTP sink. The mode can be changed by setting
+    `gid.connector.http.sink.writer.request.mode` with value `single` or `batch`. The default value
+    is `batch` bode which is breaking change comparing to previous versions. Additionally,
+    `gid.connector.http.sink.request.batch.size` option can be used to set batch size. By default,
+    batch size is 500 which is same as default value of HttpSink `maxBatchSize` parameter. 
+
+### Changed
+-   Changed API for public HttpSink builder. The `setHttpPostRequestCallback` expects a `PostRequestCallback`
+    of generic type [HttpRequest](src/main/java/com/getindata/connectors/http/internal/sink/httpclient/HttpRequest.java)
+    instead `HttpSinkRequestEntry`.
+-   Changed HTTP sink reqeust and response processing thread pool sizes from 16 to 1.
+
 ## [0.9.0] - 2023-02-10
 
 -   Add support for Flink 1.16.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This is a breaking compatibility change.
 The submission mode can be changed using `gid.connector.http.sink.writer.request.mode` property using `single` or `batch` as property value.
 
 #### Batch submission mode
-In batch mode, a number of events (processed elements) will be batched and submitted in one HTTP reqeust.
+In batch mode, a number of events (processed elements) will be batched and submitted in one HTTP request.
 In this mode, HTTP PUT/POST request's body contains a Json array, where every element of this array represents
 individual event.
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,81 @@ Due to the fact that `HttpSink` sends bytes inside HTTP request's body, one can 
 
 Other examples of usage of the Table API can be found in [some tests](src/test/java/com/getindata/connectors/http/table/HttpDynamicSinkInsertTest.java).
 
+### Request submission
+Starting from version 0.10 HTTP Sink by default submits events in batch. Before version 0.10 the default and only submission type was `single`.
+This is a breaking compatibility change.
+
+The submission mode can be changed using `gid.connector.http.sink.writer.request.mode` property using `single` or `batch` as property value.
+
+#### Batch submission mode
+In batch mode, a number of events (processed elements) will be batched and submitted in one HTTP reqeust.
+In this mode, HTTP PUT/POST request's body contains a Json array, where every element of this array represents
+individual event.
+
+An example of Http Sink batch request body containing data for three events:
+```json
+[
+  {
+    "id": 1,
+    "first_name": "Ninette",
+    "last_name": "Clee",
+    "gender": "Female",
+    "stock": "CDZI",
+    "currency": "RUB",
+    "tx_date": "2021-08-24 15:22:59"
+  },
+  {
+    "id": 2,
+    "first_name": "Rob",
+    "last_name": "Zombie",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "GBP",
+    "tx_date": "2021-10-25 20:53:54"
+  },
+  {
+    "id": 3,
+    "first_name": "Adam",
+    "last_name": "Jones",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "PLN",
+    "tx_date": "2021-10-26 20:53:54"
+  }
+]
+```
+
+By default, batch size is set to 500 which is the same as Http Sink's `maxBatchSize` property and has value of 500. 
+The `maxBatchSize' property sets maximal number of events that will by buffered by Flink runtime before passing it to Http Sink for processing.
+
+In order to change submission batch size use `gid.connector.http.sink.request.batch.size` property. For example:
+
+Streaming API:
+```java
+HttpSink.<String>builder()
+      .setEndpointUrl("http://example.com/myendpoint")
+      .setElementConverter(
+          (s, _context) -> new HttpSinkRequestEntry("POST", s.getBytes(StandardCharsets.UTF_8)))
+      .setProperty("gid.connector.http.sink.request.batch.size", "50")
+      .build();
+```
+SQL:
+```roomsql
+CREATE TABLE http (
+  id bigint,
+  some_field string
+) WITH (
+  'connector' = 'http-sink',
+  'url' = 'http://example.com/myendpoint',
+  'format' = 'json',
+  'gid.connector.http.sink.request.batch.size' = '50'
+)
+```
+
+#### Single submission mode
+In this mode every processed event is submitted as individual HTTP POST/PUT request. 
+
+
 #### Http headers
 It is possible to set HTTP headers that will be added to HTTP request send by sink connector.
 Headers are defined via property key `gid.connector.http.sink.header.HEADER_NAME = header value` for example:
@@ -307,26 +382,28 @@ If the used value starts from prefix `Basic `, it will be used as header value a
 | gid.connector.http.source.lookup.response.thread-pool.size | optional | Sets the size of pool thread for HTTP lookup response processing. Increasing this value would mean that more concurrent requests can be processed in the same time. If not specified, the default value of 4 threads will be used. |
 
 ### HTTP Sink
-| Option                                                     | Required | Description/Value                                                                                                                                                                                                                |
-|------------------------------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| connector                                                  | required | Specify what connector to use. For HTTP Sink it should be set to _'http-sink'_.                                                                                                                                                  |
-| url                                                        | required | The base URL that should be use for HTTP requests. For example _http://localhost:8080/client_.                                                                                                                                   |
-| format                                                     | required | Specify what format to use.                                                                                                                                                                                                      |
-| insert-method                                              | optional | Specify which HTTP method to use in the request. The value should be set either to `POST` or `PUT`.                                                                                                                              |
-| sink.batch.max-size                                        | optional | Maximum number of elements that may be passed in a batch to be written downstream.                                                                                                                                               |
-| sink.requests.max-inflight                                 | optional | The maximum number of in flight requests that may exist, if any more in flight requests need to be initiated once the maximum has been reached, then it will be blocked until some have completed.                               |
-| sink.requests.max-buffered                                 | optional | Maximum number of buffered records before applying backpressure.                                                                                                                                                                 |
-| sink.flush-buffer.size                                     | optional | The maximum size of a batch of entries that may be sent to the HTTP endpoint measured in bytes.                                                                                                                                  |
-| sink.flush-buffer.timeout                                  | optional | Threshold time in milliseconds for an element to be in a buffer before being flushed.                                                                                                                                            |
-| gid.connector.http.sink.request-callback                   | optional | Specify which `HttpPostRequestCallback` implementation to use. By default, it is set to `slf4j-logger` corresponding to `Slf4jHttpPostRequestCallback`.                                                                          |
-| gid.connector.http.sink.error.code                         | optional | List of HTTP status codes that should be treated as errors by HTTP Sink, separated with comma.                                                                                                                                   |
-| gid.connector.http.sink.error.code.exclude                 | optional | List of HTTP status codes that should be excluded from the `gid.connector.http.sink.error.code` list, separated with comma.                                                                                                      |
-| gid.connector.http.security.cert.server                    | optional | Path to trusted HTTP server certificate that should be add to connectors key store. More than one path can be specified using `,` as path delimiter.                                                                             |
-| gid.connector.http.security.cert.client                    | optional | Path to trusted certificate that should be used by connector's HTTP client for mTLS communication.                                                                                                                               |
-| gid.connector.http.security.key.client                     | optional | Path to trusted private key that should be used by connector's HTTP client for mTLS communication.                                                                                                                               |
-| gid.connector.http.security.cert.server.allowSelfSigned    | optional | Accept untrusted certificates for TLS communication.                                                                                                                                                                             |
-| gid.connector.http.sink.request.timeout                    | optional | Sets HTTP request timeout in seconds. If not specified, the default value of 30 seconds will be used.                                                                                                                            |
-| gid.connector.http.sink.writer.thread-pool.size            | optional | Sets the size of pool thread for HTTP Sink request processing. Increasing this value would mean that more concurrent requests can be processed in the same time. If not specified, the default value of 16 threads will be used. |
+| Option                                                  | Required | Description/Value                                                                                                                                                                                                                                |
+|---------------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| connector                                               | required | Specify what connector to use. For HTTP Sink it should be set to _'http-sink'_.                                                                                                                                                                  |
+| url                                                     | required | The base URL that should be use for HTTP requests. For example _http://localhost:8080/client_.                                                                                                                                                   |
+| format                                                  | required | Specify what format to use.                                                                                                                                                                                                                      |
+| insert-method                                           | optional | Specify which HTTP method to use in the request. The value should be set either to `POST` or `PUT`.                                                                                                                                              |
+| sink.batch.max-size                                     | optional | Maximum number of elements that may be passed in a batch to be written downstream.                                                                                                                                                               |
+| sink.requests.max-inflight                              | optional | The maximum number of in flight requests that may exist, if any more in flight requests need to be initiated once the maximum has been reached, then it will be blocked until some have completed.                                               |
+| sink.requests.max-buffered                              | optional | Maximum number of buffered records before applying backpressure.                                                                                                                                                                                 |
+| sink.flush-buffer.size                                  | optional | The maximum size of a batch of entries that may be sent to the HTTP endpoint measured in bytes.                                                                                                                                                  |
+| sink.flush-buffer.timeout                               | optional | Threshold time in milliseconds for an element to be in a buffer before being flushed.                                                                                                                                                            |
+| gid.connector.http.sink.request-callback                | optional | Specify which `HttpPostRequestCallback` implementation to use. By default, it is set to `slf4j-logger` corresponding to `Slf4jHttpPostRequestCallback`.                                                                                          |
+| gid.connector.http.sink.error.code                      | optional | List of HTTP status codes that should be treated as errors by HTTP Sink, separated with comma.                                                                                                                                                   |
+| gid.connector.http.sink.error.code.exclude              | optional | List of HTTP status codes that should be excluded from the `gid.connector.http.sink.error.code` list, separated with comma.                                                                                                                      |
+| gid.connector.http.security.cert.server                 | optional | Path to trusted HTTP server certificate that should be add to connectors key store. More than one path can be specified using `,` as path delimiter.                                                                                             |
+| gid.connector.http.security.cert.client                 | optional | Path to trusted certificate that should be used by connector's HTTP client for mTLS communication.                                                                                                                                               |
+| gid.connector.http.security.key.client                  | optional | Path to trusted private key that should be used by connector's HTTP client for mTLS communication.                                                                                                                                               |
+| gid.connector.http.security.cert.server.allowSelfSigned | optional | Accept untrusted certificates for TLS communication.                                                                                                                                                                                             |
+| gid.connector.http.sink.request.timeout                 | optional | Sets HTTP request timeout in seconds. If not specified, the default value of 30 seconds will be used.                                                                                                                                            |
+| gid.connector.http.sink.writer.thread-pool.size         | optional | Sets the size of pool thread for HTTP Sink request processing. Increasing this value would mean that more concurrent requests can be processed in the same time. If not specified, the default value of 1 thread will be used.                   |
+| gid.connector.http.sink.writer.request.mode             | optional | Sets Http Sink request submission mode. Two modes are available to select, `single` and `batch` which is the default mode if option is not specified.                                                                                            |
+| gid.connector.http.sink.request.batch.size              | optional | Applicable only for `gid.connector.http.sink.writer.request.mode = batch`. Sets number of individual events/requests that will be submitted as one HTTP request by HTTP sink. The default value is 500 which is same as HTTP Sink `maxBatchSize` |
 
 ## Build and deployment
 To build the project locally you need to have `maven 3` and Java 11+. </br>
@@ -403,6 +480,13 @@ Implementation of an HTTP Sink is based on Flink's `AsyncSinkBase` introduced in
 
 #### Http Response to Table schema mapping
 The mapping from Http Json Response to SQL table schema is done via Flink's Json Format [5].
+
+## Breaking changes
+- Version 0.10
+  - Http Sink submission mode changed from single to batch. From now, body of HTTP POUT/POST request will contain a Json array.
+  - Changed API for public HttpSink builder. The `setHttpPostRequestCallback` expects a `PostRequestCallback`
+    of generic type [HttpRequest](src/main/java/com/getindata/connectors/http/internal/sink/httpclient/HttpRequest.java)
+    instead `HttpSinkRequestEntry`.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The goal for HTTP TableLookup connector was to use it in Flink SQL statement as 
 Currently, HTTP source connector supports only Lookup Joins (TableLookup) [1] in Table/SQL API.
 `HttpSink` supports both Streaming API (when using [HttpSink](src/main/java/com/getindata/connectors/http/internal/sink/HttpSink.java) built using [HttpSinkBuilder](src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilder.java)) and the Table API (using connector created in [HttpDynamicTableSinkFactory](src/main/java/com/getindata/connectors/http/internal/table/HttpDynamicTableSinkFactory.java)). 
 
+## Updating the connector
+In case of updating http-connector please see [Breaking changes](#breaking-changes) section.
+
 ## Prerequisites
 * Java 11
 * Maven 3

--- a/src/main/java/com/getindata/connectors/http/HttpSink.java
+++ b/src/main/java/com/getindata/connectors/http/HttpSink.java
@@ -9,6 +9,7 @@ import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
 import com.getindata.connectors.http.internal.sink.HttpSinkInternal;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 
 /**
  * A public implementation for {@code HttpSink} that performs async requests against a specified
@@ -41,7 +42,7 @@ public class HttpSink<InputT> extends HttpSinkInternal<InputT> {
             long maxTimeInBufferMS,
             long maxRecordSizeInBytes,
             String endpointUrl,
-            HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+            HttpPostRequestCallback<HttpRequest> httpPostRequestCallback,
             HeaderPreprocessor headerPreprocessor,
             SinkHttpClientBuilder sinkHttpClientBuilder,
             Properties properties) {

--- a/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
+++ b/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
@@ -11,6 +11,7 @@ import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.SinkHttpClient;
 import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.sink.httpclient.JavaNetSinkHttpClient;
 import com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallback;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
@@ -62,7 +63,7 @@ public class HttpSinkBuilder<InputT> extends
 
     private static final SinkHttpClientBuilder DEFAULT_CLIENT_BUILDER = JavaNetSinkHttpClient::new;
 
-    private static final HttpPostRequestCallback<HttpSinkRequestEntry>
+    private static final HttpPostRequestCallback<HttpRequest>
         DEFAULT_POST_REQUEST_CALLBACK = new Slf4jHttpPostRequestCallback();
 
     private static final HeaderPreprocessor DEFAULT_HEADER_PREPROCESSOR =
@@ -80,7 +81,7 @@ public class HttpSinkBuilder<InputT> extends
     private SinkHttpClientBuilder sinkHttpClientBuilder;
 
     // If not defined, should be set to DEFAULT_POST_REQUEST_CALLBACK
-    private HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback;
+    private HttpPostRequestCallback<HttpRequest> httpPostRequestCallback;
 
     // If not defined, should be set to DEFAULT_HEADER_PREPROCESSOR
     private HeaderPreprocessor headerPreprocessor;
@@ -138,7 +139,7 @@ public class HttpSinkBuilder<InputT> extends
     }
 
     public HttpSinkBuilder<InputT> setHttpPostRequestCallback(
-        HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback) {
+        HttpPostRequestCallback<HttpRequest> httpPostRequestCallback) {
         this.httpPostRequestCallback = httpPostRequestCallback;
         return this;
     }

--- a/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientBuilder.java
+++ b/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientBuilder.java
@@ -7,6 +7,7 @@ import org.apache.flink.annotation.PublicEvolving;
 
 import com.getindata.connectors.http.HttpPostRequestCallback;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.RequestSubmitterFactory;
 
 /**
  * Builder building {@link SinkHttpClient}.
@@ -14,11 +15,12 @@ import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 @PublicEvolving
 public interface SinkHttpClientBuilder extends Serializable {
 
-    // TODO Consider moving HttpPostRequestCallback and HeaderPreprocessor to be a
+    // TODO Consider moving HttpPostRequestCallback and HeaderPreprocessor, RequestSubmitter to be a
     //  SinkHttpClientBuilder fields. This method is getting more and more arguments.
     SinkHttpClient build(
         Properties properties,
         HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
-        HeaderPreprocessor headerPreprocessor
+        HeaderPreprocessor headerPreprocessor,
+        RequestSubmitterFactory requestSubmitterFactory
     );
 }

--- a/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientBuilder.java
+++ b/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientBuilder.java
@@ -6,7 +6,7 @@ import java.util.Properties;
 import org.apache.flink.annotation.PublicEvolving;
 
 import com.getindata.connectors.http.HttpPostRequestCallback;
-import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.sink.httpclient.RequestSubmitterFactory;
 
 /**
@@ -19,8 +19,9 @@ public interface SinkHttpClientBuilder extends Serializable {
     //  SinkHttpClientBuilder fields. This method is getting more and more arguments.
     SinkHttpClient build(
         Properties properties,
-        HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+        HttpPostRequestCallback<HttpRequest> httpPostRequestCallback,
         HeaderPreprocessor headerPreprocessor,
         RequestSubmitterFactory requestSubmitterFactory
+
     );
 }

--- a/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientResponse.java
+++ b/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientResponse.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.ToString;
 
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 
 /**
  * Data class holding {@link HttpSinkRequestEntry} instances that {@link SinkHttpClient} attempted
@@ -20,11 +21,11 @@ public class SinkHttpClientResponse {
      * A list of successfully written requests.
      */
     @NonNull
-    private final List<HttpSinkRequestEntry> successfulRequests;
+    private final List<HttpRequest> successfulRequests;
 
     /**
      * A list of requests that {@link SinkHttpClient} failed to write.
      */
     @NonNull
-    private final List<HttpSinkRequestEntry> failedRequests;
+    private final List<HttpRequest> failedRequests;
 }

--- a/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
+++ b/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
@@ -74,6 +74,9 @@ public final class HttpConnectorConfigConstants {
     public static final String SINK_HTTP_TIMEOUT_SECONDS =
         GID_CONNECTOR_HTTP + "sink.request.timeout";
 
+    public static final String SINK_HTTP_BATCH_REQUEST_SIZE =
+        GID_CONNECTOR_HTTP + "sink.request.batch.size";
+
     public static final String LOOKUP_HTTP_PULING_THREAD_POOL_SIZE =
         GID_CONNECTOR_HTTP + "source.lookup.request.thread-pool.size";
 

--- a/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
+++ b/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
@@ -87,7 +87,7 @@ public final class HttpConnectorConfigConstants {
     // -----------------------------------------------------
 
 
-    // ------ Sink reqeust submitter settings ------
+    // ------ Sink request submitter settings ------
     public static final String SINK_HTTP_REQUEST_MODE =
         GID_CONNECTOR_HTTP + "sink.writer.request.mode";
 

--- a/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
+++ b/src/main/java/com/getindata/connectors/http/internal/config/HttpConnectorConfigConstants.java
@@ -9,6 +9,7 @@ import lombok.experimental.UtilityClass;
  */
 @UtilityClass
 @NoArgsConstructor(access = AccessLevel.NONE)
+// TODO Change this name to HttpConnectorConfigProperties
 public final class HttpConnectorConfigConstants {
 
     public static final String PROP_DELIM = ",";
@@ -74,9 +75,6 @@ public final class HttpConnectorConfigConstants {
     public static final String SINK_HTTP_TIMEOUT_SECONDS =
         GID_CONNECTOR_HTTP + "sink.request.timeout";
 
-    public static final String SINK_HTTP_BATCH_REQUEST_SIZE =
-        GID_CONNECTOR_HTTP + "sink.request.batch.size";
-
     public static final String LOOKUP_HTTP_PULING_THREAD_POOL_SIZE =
         GID_CONNECTOR_HTTP + "source.lookup.request.thread-pool.size";
 
@@ -87,4 +85,14 @@ public final class HttpConnectorConfigConstants {
         GID_CONNECTOR_HTTP + "sink.writer.thread-pool.size";
 
     // -----------------------------------------------------
+
+
+    // ------ Sink reqeust submitter settings ------
+    public static final String SINK_HTTP_REQUEST_MODE =
+        GID_CONNECTOR_HTTP + "sink.writer.request.mode";
+
+    public static final String SINK_HTTP_BATCH_REQUEST_SIZE =
+        GID_CONNECTOR_HTTP + "sink.request.batch.size";
+
+    // ---------------------------------------------
 }

--- a/src/main/java/com/getindata/connectors/http/internal/config/SinkRequestSubmitMode.java
+++ b/src/main/java/com/getindata/connectors/http/internal/config/SinkRequestSubmitMode.java
@@ -2,8 +2,8 @@ package com.getindata.connectors.http.internal.config;
 
 public enum SinkRequestSubmitMode {
 
-    PER_REQUEST("PerRequest"),
-    BATCH("Batch");
+    SINGLE("single"),
+    BATCH("batch");
 
     private final String mode;
 

--- a/src/main/java/com/getindata/connectors/http/internal/config/SinkRequestSubmitMode.java
+++ b/src/main/java/com/getindata/connectors/http/internal/config/SinkRequestSubmitMode.java
@@ -1,0 +1,17 @@
+package com.getindata.connectors.http.internal.config;
+
+public enum SinkRequestSubmitMode {
+
+    PER_REQUEST("PerRequest"),
+    BATCH("Batch");
+
+    private final String mode;
+
+    SinkRequestSubmitMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
@@ -178,7 +178,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
 
     private RequestSubmitterFactory getRequestSubmitterFactory() {
 
-        if (SinkRequestSubmitMode.PER_REQUEST.getMode().equalsIgnoreCase(
+        if (SinkRequestSubmitMode.SINGLE.getMode().equalsIgnoreCase(
             properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_REQUEST_MODE))) {
             return new PerRequestRequestSubmitterFactory();
         }

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
@@ -19,6 +19,7 @@ import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
 import com.getindata.connectors.http.internal.config.SinkRequestSubmitMode;
 import com.getindata.connectors.http.internal.sink.httpclient.BatchRequestSubmitterFactory;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.sink.httpclient.PerRequestRequestSubmitterFactory;
 import com.getindata.connectors.http.internal.sink.httpclient.RequestSubmitterFactory;
 
@@ -64,7 +65,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
     // makes it possible to serialize `HttpSink`
     private final SinkHttpClientBuilder sinkHttpClientBuilder;
 
-    private final HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback;
+    private final HttpPostRequestCallback<HttpRequest> httpPostRequestCallback;
 
     private final HeaderPreprocessor headerPreprocessor;
 
@@ -79,7 +80,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
         long maxTimeInBufferMS,
         long maxRecordSizeInBytes,
         String endpointUrl,
-        HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+        HttpPostRequestCallback<HttpRequest> httpPostRequestCallback,
         HeaderPreprocessor headerPreprocessor,
         SinkHttpClientBuilder sinkHttpClientBuilder,
         Properties properties) {

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/AbstractRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/AbstractRequestSubmitter.java
@@ -13,7 +13,11 @@ import com.getindata.connectors.http.internal.utils.ThreadUtils;
 
 public abstract class AbstractRequestSubmitter implements RequestSubmitter {
 
-    protected static final int HTTP_CLIENT_THREAD_POOL_SIZE = 16;
+    // TODO Add this property to config. Make sure to add note in README.md that will describe that
+    //  any value greater than one will break order of messages.
+    protected static final int HTTP_CLIENT_THREAD_POOL_SIZE = 1;
+
+    protected static final int HTTP_CLIENT_PUBLISHING_THREAD_POOL_SIZE = 1;
 
     protected static final String DEFAULT_REQUEST_TIMEOUT_SECONDS = "30";
 
@@ -33,7 +37,7 @@ public abstract class AbstractRequestSubmitter implements RequestSubmitter {
         this.headersAndValues = headersAndValues;
         this.publishingThreadPool =
             Executors.newFixedThreadPool(
-                HTTP_CLIENT_THREAD_POOL_SIZE,
+                HTTP_CLIENT_PUBLISHING_THREAD_POOL_SIZE,
                 new ExecutorThreadFactory(
                     "http-sink-client-response-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
 

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/AbstractRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/AbstractRequestSubmitter.java
@@ -1,0 +1,53 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.net.http.HttpClient;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
+import com.getindata.connectors.http.internal.utils.ThreadUtils;
+
+public abstract class AbstractRequestSubmitter implements RequestSubmitter {
+
+    protected static final int HTTP_CLIENT_THREAD_POOL_SIZE = 16;
+
+    protected static final String DEFAULT_REQUEST_TIMEOUT_SECONDS = "30";
+
+    /**
+     * Thread pool to handle HTTP response from HTTP client.
+     */
+    protected final ExecutorService publishingThreadPool;
+
+    protected final int httpRequestTimeOutSeconds;
+
+    protected final String[] headersAndValues;
+
+    protected final HttpClient httpClient;
+
+    public AbstractRequestSubmitter(Properties properties, String[] headersAndValues) {
+
+        this.headersAndValues = headersAndValues;
+        this.publishingThreadPool =
+            Executors.newFixedThreadPool(
+                HTTP_CLIENT_THREAD_POOL_SIZE,
+                new ExecutorThreadFactory(
+                    "http-sink-client-response-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
+
+        this.httpRequestTimeOutSeconds = Integer.parseInt(
+            properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_TIMEOUT_SECONDS,
+                DEFAULT_REQUEST_TIMEOUT_SECONDS)
+        );
+
+        ExecutorService httpClientExecutor =
+            Executors.newFixedThreadPool(
+                HTTP_CLIENT_THREAD_POOL_SIZE,
+                new ExecutorThreadFactory(
+                    "http-sink-client-request-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
+
+        this.httpClient = JavaNetHttpClientFactory.createClient(properties, httpClientExecutor);
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/AbstractRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/AbstractRequestSubmitter.java
@@ -8,14 +8,9 @@ import java.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
-import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
 import com.getindata.connectors.http.internal.utils.ThreadUtils;
 
 public abstract class AbstractRequestSubmitter implements RequestSubmitter {
-
-    // TODO Add this property to config. Make sure to add note in README.md that will describe that
-    //  any value greater than one will break order of messages.
-    protected static final int HTTP_CLIENT_THREAD_POOL_SIZE = 1;
 
     protected static final int HTTP_CLIENT_PUBLISHING_THREAD_POOL_SIZE = 1;
 
@@ -32,7 +27,10 @@ public abstract class AbstractRequestSubmitter implements RequestSubmitter {
 
     protected final HttpClient httpClient;
 
-    public AbstractRequestSubmitter(Properties properties, String[] headersAndValues) {
+    public AbstractRequestSubmitter(
+            Properties properties,
+            String[] headersAndValues,
+            HttpClient httpClient) {
 
         this.headersAndValues = headersAndValues;
         this.publishingThreadPool =
@@ -46,12 +44,6 @@ public abstract class AbstractRequestSubmitter implements RequestSubmitter {
                 DEFAULT_REQUEST_TIMEOUT_SECONDS)
         );
 
-        ExecutorService httpClientExecutor =
-            Executors.newFixedThreadPool(
-                HTTP_CLIENT_THREAD_POOL_SIZE,
-                new ExecutorThreadFactory(
-                    "http-sink-client-request-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
-
-        this.httpClient = JavaNetHttpClientFactory.createClient(properties, httpClientExecutor);
+        this.httpClient = httpClient;
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
@@ -1,0 +1,125 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.net.URI;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+
+@Slf4j
+public class BatchRequestSubmitter extends AbstractRequestSubmitter {
+
+    // TODO HTTP-42 we MUST use maxBatchSize from HttpSink here
+    protected static final String DEFAULT_HTTP_BATCH_REQUEST_SIZE = "20";
+
+    private final int httpReqeustBatchSize;
+
+    public BatchRequestSubmitter(Properties properties, String[] headersAndValue) {
+        super(properties, headersAndValue);
+
+        this.httpReqeustBatchSize = Integer.parseInt(
+            properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+                DEFAULT_HTTP_BATCH_REQUEST_SIZE)
+        );
+    }
+
+    @Override
+    public List<CompletableFuture<JavaNetHttpResponseWrapper>> submit(
+            String endpointUrl,
+            List<HttpSinkRequestEntry> requestToSubmit) {
+
+        var responseFutures = new ArrayList<CompletableFuture<JavaNetHttpResponseWrapper>>();
+
+        int counter = 0;
+        String previousReqeustMethod = "";
+        List<HttpSinkRequestEntry> reqeustBatch = new ArrayList<>(httpReqeustBatchSize);
+        for (var entry : requestToSubmit) {
+
+            if (++counter % httpReqeustBatchSize == 0
+                || (!reqeustBatch.isEmpty() && !previousReqeustMethod.equalsIgnoreCase(
+                entry.method))) {
+                responseFutures.add(sendBatch(endpointUrl, reqeustBatch));
+                reqeustBatch.clear();
+            } else {
+                reqeustBatch.add(entry);
+            }
+        }
+
+        if (!reqeustBatch.isEmpty()) {
+            responseFutures.add(sendBatch(endpointUrl, reqeustBatch));
+        }
+
+        return responseFutures;
+    }
+
+    private CompletableFuture<JavaNetHttpResponseWrapper> sendBatch(
+            String endpointUrl,
+            List<HttpSinkRequestEntry> reqeustBatch) {
+
+        var endpointUri = URI.create(endpointUrl);
+        return httpClient
+            .sendAsync(
+                buildHttpRequest(reqeustBatch, endpointUri),
+                HttpResponse.BodyHandlers.ofString())
+            .exceptionally(ex -> {
+                // TODO This will be executed on a ForJoinPool Thread... refactor this someday.
+                log.error("Request fatally failed because of an exception", ex);
+                return null;
+            })
+            .thenApplyAsync(
+                // TODO HTTP-42
+                res -> new JavaNetHttpResponseWrapper(reqeustBatch.get(0), res),
+                publishingThreadPool
+            );
+    }
+
+    private HttpRequest buildHttpRequest(List<HttpSinkRequestEntry> reqeustBatch, URI endpointUri) {
+
+        try {
+            var method = reqeustBatch.get(0).method;
+
+            /*long totalSize =
+                reqeustBatch.stream().mapToLong(HttpSinkRequestEntry::getSizeInBytes).sum();
+            ByteBuffer byteBuffer = ByteBuffer.allocate((int) totalSize);
+
+            for (HttpSinkRequestEntry entry : reqeustBatch) {
+                byteBuffer.put(entry.element);
+            }
+            BodyPublisher publisher = BodyPublishers.ofByteArray(byteBuffer.array());*/
+
+            List<byte[]> elements =
+                reqeustBatch.stream().map(entry -> entry.element).collect(Collectors.toList());
+            BodyPublisher publisher = BodyPublishers.ofByteArrays(elements);
+
+            Builder requestBuilder = HttpRequest
+                .newBuilder()
+                .uri(endpointUri)
+                .version(Version.HTTP_1_1)
+                .timeout(Duration.ofSeconds(httpRequestTimeOutSeconds))
+                .method(method, publisher);
+
+            if (headersAndValues.length != 0) {
+                requestBuilder.headers(headersAndValues);
+            }
+
+            return requestBuilder.build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
@@ -34,7 +34,7 @@ public class BatchRequestSubmitter extends AbstractRequestSubmitter {
 
     private static final byte[] BATCH_ELEMENT_DELIM_BYTES = ",".getBytes(StandardCharsets.UTF_8);
 
-    private final int httpReqeustBatchSize;
+    private final int httpRequestBatchSize;
 
     public BatchRequestSubmitter(
             Properties properties,
@@ -43,7 +43,7 @@ public class BatchRequestSubmitter extends AbstractRequestSubmitter {
 
         super(properties, headersAndValue, httpClient);
 
-        this.httpReqeustBatchSize = Integer.parseInt(
+        this.httpRequestBatchSize = Integer.parseInt(
             properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE)
         );
     }
@@ -61,7 +61,7 @@ public class BatchRequestSubmitter extends AbstractRequestSubmitter {
 
         int counter = 0;
         String previousReqeustMethod = requestsToSubmit.get(0).method;
-        List<HttpSinkRequestEntry> reqeustBatch = new ArrayList<>(httpReqeustBatchSize);
+        List<HttpSinkRequestEntry> reqeustBatch = new ArrayList<>(httpRequestBatchSize);
         for (var entry : requestsToSubmit) {
             if (!previousReqeustMethod.equalsIgnoreCase(entry.method)) {
                 // break batch and submit
@@ -71,7 +71,7 @@ public class BatchRequestSubmitter extends AbstractRequestSubmitter {
                 reqeustBatch.add(entry);
             } else {
                 reqeustBatch.add(entry);
-                if (++counter % httpReqeustBatchSize == 0) {
+                if (++counter % httpRequestBatchSize == 0) {
                     // batch is full, submit and start new batch.
                     responseFutures.add(sendBatch(endpointUrl, reqeustBatch));
                     reqeustBatch.clear();
@@ -89,7 +89,7 @@ public class BatchRequestSubmitter extends AbstractRequestSubmitter {
 
     @VisibleForTesting
     int getBatchSize() {
-        return httpReqeustBatchSize;
+        return httpRequestBatchSize;
     }
 
     private CompletableFuture<JavaNetHttpResponseWrapper> sendBatch(

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
@@ -21,6 +21,10 @@ import org.apache.flink.annotation.VisibleForTesting;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 
+/**
+ * This implementation groups received events in batches and submits each batch as individual HTTP
+ * requests. Batch is created based on batch size or based on HTTP method type.
+ */
 @Slf4j
 public class BatchRequestSubmitter extends AbstractRequestSubmitter {
 

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
@@ -62,6 +62,7 @@ public class BatchRequestSubmitter extends AbstractRequestSubmitter {
             String endpointUrl,
             List<HttpSinkRequestEntry> reqeustBatch) {
 
+        System.out.println("aaaaa " + new String(reqeustBatch.get(0).element));
         var endpointUri = URI.create(endpointUrl);
         return httpClient
             .sendAsync(

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitterFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitterFactory.java
@@ -1,0 +1,50 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.util.Properties;
+
+import org.apache.flink.util.StringUtils;
+
+import com.getindata.connectors.http.internal.config.ConfigException;
+import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+
+public class BatchRequestSubmitterFactory implements RequestSubmitterFactory {
+
+    private final String maxBatchSize;
+
+    public BatchRequestSubmitterFactory(int maxBatchSize) {
+        this.maxBatchSize = String.valueOf(maxBatchSize);
+    }
+
+    @Override
+    public RequestSubmitter createSubmitter(Properties properties, String[] headersAndValues) {
+        String batchRequestSize =
+            properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE);
+        if (StringUtils.isNullOrWhitespaceOnly(batchRequestSize)) {
+            properties.setProperty(
+                HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+                maxBatchSize
+            );
+        } else {
+            try {
+                // TODO Create property validator someday.
+                int batchSize = Integer.parseInt(batchRequestSize);
+                if (batchSize < 1) {
+                    throw new ConfigException(
+                        String.format("Property %s must be greater than 0 but was: %s",
+                            HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+                            batchRequestSize)
+                    );
+                }
+            } catch (NumberFormatException e) {
+                // TODO Create property validator someday.
+                throw new ConfigException(
+                    String.format("Property %s must be an integer but was: %s",
+                        HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+                        batchRequestSize),
+                    e
+                );
+            }
+        }
+        return new BatchRequestSubmitter(properties, headersAndValues);
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/HttpRequest.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/HttpRequest.java
@@ -1,0 +1,16 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class HttpRequest {
+
+    public final java.net.http.HttpRequest httpRequest;
+
+    public final List<byte[]> elements;
+
+    public final String method;
+
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetHttpResponseWrapper.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetHttpResponseWrapper.java
@@ -20,7 +20,7 @@ final class JavaNetHttpResponseWrapper {
      * A representation of a single {@link com.getindata.connectors.http.HttpSink} request.
      */
     @NonNull
-    private final HttpSinkRequestEntry sinkRequestEntry;
+    private final HttpRequest httpRequest;
 
     /**
      * A response to an HTTP request based on {@link HttpSinkRequestEntry}.

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
@@ -70,7 +70,8 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
 
         // TODO HTTP-42
         this.headersAndValues = HttpHeaderUtils.toHeaderAndValueArray(this.headerMap);
-        this.requestSubmitter = new PerRequestSubmitter(properties, headersAndValues);
+        //this.requestSubmitter = new PerRequestSubmitter(properties, headersAndValues);
+        this.requestSubmitter = new BatchRequestSubmitter(properties, headersAndValues);
     }
 
     @Override

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
@@ -21,7 +21,6 @@ import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 import com.getindata.connectors.http.internal.status.ComposeHttpStatusCodeChecker;
 import com.getindata.connectors.http.internal.status.ComposeHttpStatusCodeChecker.ComposeHttpStatusCodeCheckerConfig;
 import com.getindata.connectors.http.internal.status.HttpStatusCodeChecker;
-import com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallback;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 
 /**
@@ -41,14 +40,11 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
 
     private final RequestSubmitter requestSubmitter;
 
-    public JavaNetSinkHttpClient(Properties properties, HeaderPreprocessor headerPreprocessor) {
-        this(properties, new Slf4jHttpPostRequestCallback(), headerPreprocessor);
-    }
-
     public JavaNetSinkHttpClient(
             Properties properties,
             HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
-            HeaderPreprocessor headerPreprocessor) {
+            HeaderPreprocessor headerPreprocessor,
+            RequestSubmitterFactory requestSubmitterFactory) {
 
         this.httpPostRequestCallback = httpPostRequestCallback;
         this.headerMap = HttpHeaderUtils.prepareHeaderMap(
@@ -68,10 +64,11 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
 
         this.statusCodeChecker = new ComposeHttpStatusCodeChecker(checkerConfig);
 
-        // TODO HTTP-42
         this.headersAndValues = HttpHeaderUtils.toHeaderAndValueArray(this.headerMap);
-        //this.requestSubmitter = new PerRequestSubmitter(properties, headersAndValues);
-        this.requestSubmitter = new BatchRequestSubmitter(properties, headersAndValues);
+        this.requestSubmitter = requestSubmitterFactory.createSubmitter(
+            properties,
+            headersAndValues
+        );
     }
 
     @Override

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
@@ -1,26 +1,16 @@
 package com.getindata.connectors.http.internal.sink.httpclient;
 
-import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpClient.Version;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpRequest.Builder;
-import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import com.getindata.connectors.http.HttpPostRequestCallback;
 import com.getindata.connectors.http.internal.HeaderPreprocessor;
@@ -33,8 +23,6 @@ import com.getindata.connectors.http.internal.status.ComposeHttpStatusCodeChecke
 import com.getindata.connectors.http.internal.status.HttpStatusCodeChecker;
 import com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallback;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
-import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
-import com.getindata.connectors.http.internal.utils.ThreadUtils;
 
 /**
  * An implementation of {@link SinkHttpClient} that uses Java 11's {@link HttpClient}. This
@@ -42,12 +30,6 @@ import com.getindata.connectors.http.internal.utils.ThreadUtils;
  */
 @Slf4j
 public class JavaNetSinkHttpClient implements SinkHttpClient {
-
-    private static final int HTTP_CLIENT_THREAD_POOL_SIZE = 16;
-
-    public static final String DEFAULT_REQUEST_TIMEOUT_SECONDS = "30";
-
-    private final HttpClient httpClient;
 
     private final String[] headersAndValues;
 
@@ -57,36 +39,23 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
 
     private final HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback;
 
-    /**
-     * Thread pool to handle HTTP response from HTTP client.
-     */
-    private final ExecutorService publishingThreadPool;
-
-    private final int httpRequestTimeOutSeconds;
+    private final RequestSubmitter requestSubmitter;
 
     public JavaNetSinkHttpClient(Properties properties, HeaderPreprocessor headerPreprocessor) {
         this(properties, new Slf4jHttpPostRequestCallback(), headerPreprocessor);
     }
 
     public JavaNetSinkHttpClient(
-        Properties properties,
-        HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
-        HeaderPreprocessor headerPreprocessor) {
+            Properties properties,
+            HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+            HeaderPreprocessor headerPreprocessor) {
 
-        ExecutorService httpClientExecutor =
-            Executors.newFixedThreadPool(
-                HTTP_CLIENT_THREAD_POOL_SIZE,
-                new ExecutorThreadFactory(
-                    "http-sink-client-request-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
-
-        this.httpClient = JavaNetHttpClientFactory.createClient(properties, httpClientExecutor);
         this.httpPostRequestCallback = httpPostRequestCallback;
         this.headerMap = HttpHeaderUtils.prepareHeaderMap(
             HttpConnectorConfigConstants.SINK_HEADER_PREFIX,
             properties,
             headerPreprocessor
         );
-        this.headersAndValues = HttpHeaderUtils.toHeaderAndValueArray(this.headerMap);
 
         // TODO Inject this via constructor when implementing a response processor.
         //  Processor will be injected and it will wrap statusChecker implementation.
@@ -99,16 +68,9 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
 
         this.statusCodeChecker = new ComposeHttpStatusCodeChecker(checkerConfig);
 
-        this.publishingThreadPool =
-            Executors.newFixedThreadPool(
-                HTTP_CLIENT_THREAD_POOL_SIZE,
-                new ExecutorThreadFactory(
-                    "http-sink-client-response-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
-
-        this.httpRequestTimeOutSeconds = Integer.parseInt(
-            properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_TIMEOUT_SECONDS,
-                DEFAULT_REQUEST_TIMEOUT_SECONDS)
-        );
+        // TODO HTTP-42
+        this.headersAndValues = HttpHeaderUtils.toHeaderAndValueArray(this.headerMap);
+        this.requestSubmitter = new PerRequestSubmitter(properties, headersAndValues);
     }
 
     @Override
@@ -119,45 +81,11 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
             .thenApply(responses -> prepareSinkHttpClientResponse(responses, endpointUrl));
     }
 
-    private HttpRequest buildHttpRequest(HttpSinkRequestEntry requestEntry, URI endpointUri) {
-        Builder requestBuilder = HttpRequest
-            .newBuilder()
-            .uri(endpointUri)
-            .version(Version.HTTP_1_1)
-            .timeout(Duration.ofSeconds(httpRequestTimeOutSeconds))
-            .method(requestEntry.method,
-                BodyPublishers.ofByteArray(requestEntry.element));
-
-        if (headersAndValues.length != 0) {
-            requestBuilder.headers(headersAndValues);
-        }
-
-        return requestBuilder.build();
-    }
-
     private CompletableFuture<List<JavaNetHttpResponseWrapper>> submitRequests(
-        List<HttpSinkRequestEntry> requestEntries,
-        String endpointUrl) {
-        var endpointUri = URI.create(endpointUrl);
-        var responseFutures = new ArrayList<CompletableFuture<JavaNetHttpResponseWrapper>>();
+            List<HttpSinkRequestEntry> requestEntries,
+            String endpointUrl) {
 
-        for (var entry : requestEntries) {
-            var response = httpClient
-                .sendAsync(
-                    buildHttpRequest(entry, endpointUri),
-                    HttpResponse.BodyHandlers.ofString())
-                .exceptionally(ex -> {
-                    // TODO This will be executed on a ForJoinPool Thread... refactor this someday.
-                    log.error("Request fatally failed because of an exception", ex);
-                    return null;
-                })
-                .thenApplyAsync(
-                    res -> new JavaNetHttpResponseWrapper(entry, res),
-                    publishingThreadPool
-                );
-            responseFutures.add(response);
-        }
-
+        var responseFutures = requestSubmitter.submit(endpointUrl, requestEntries);
         var allFutures = CompletableFuture.allOf(responseFutures.toArray(new CompletableFuture[0]));
         return allFutures.thenApply(_void -> responseFutures.stream().map(CompletableFuture::join)
             .collect(Collectors.toList()));

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
@@ -36,13 +36,13 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
 
     private final HttpStatusCodeChecker statusCodeChecker;
 
-    private final HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback;
+    private final HttpPostRequestCallback<HttpRequest> httpPostRequestCallback;
 
     private final RequestSubmitter requestSubmitter;
 
     public JavaNetSinkHttpClient(
             Properties properties,
-            HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+            HttpPostRequestCallback<HttpRequest> httpPostRequestCallback,
             HeaderPreprocessor headerPreprocessor,
             RequestSubmitterFactory requestSubmitterFactory) {
 
@@ -92,11 +92,11 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
     private SinkHttpClientResponse prepareSinkHttpClientResponse(
         List<JavaNetHttpResponseWrapper> responses,
         String endpointUrl) {
-        var successfulResponses = new ArrayList<HttpSinkRequestEntry>();
-        var failedResponses = new ArrayList<HttpSinkRequestEntry>();
+        var successfulResponses = new ArrayList<HttpRequest>();
+        var failedResponses = new ArrayList<HttpRequest>();
 
         for (var response : responses) {
-            var sinkRequestEntry = response.getSinkRequestEntry();
+            var sinkRequestEntry = response.getHttpRequest();
             var optResponse = response.getResponse();
 
             httpPostRequestCallback.call(

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestRequestSubmitterFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestRequestSubmitterFactory.java
@@ -1,0 +1,11 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.util.Properties;
+
+public class PerRequestRequestSubmitterFactory implements RequestSubmitterFactory {
+
+    @Override
+    public RequestSubmitter createSubmitter(Properties properties, String[] headersAndValues) {
+        return new PerRequestSubmitter(properties, headersAndValues);
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestRequestSubmitterFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestRequestSubmitterFactory.java
@@ -1,11 +1,33 @@
 package com.getindata.connectors.http.internal.sink.httpclient;
 
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
+import com.getindata.connectors.http.internal.utils.ThreadUtils;
 
 public class PerRequestRequestSubmitterFactory implements RequestSubmitterFactory {
 
+    // TODO Add this property to config. Make sure to add note in README.md that will describe that
+    //  any value greater than one will break order of messages.
+    int HTTP_CLIENT_THREAD_POOL_SIZE = 1;
+
     @Override
     public RequestSubmitter createSubmitter(Properties properties, String[] headersAndValues) {
-        return new PerRequestSubmitter(properties, headersAndValues);
+
+        ExecutorService httpClientExecutor =
+            Executors.newFixedThreadPool(
+                HTTP_CLIENT_THREAD_POOL_SIZE,
+                new ExecutorThreadFactory(
+                    "http-sink-client-per-request-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
+
+        return new PerRequestSubmitter(
+                properties,
+                headersAndValues,
+                JavaNetHttpClientFactory.createClient(properties, httpClientExecutor)
+            );
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
@@ -37,7 +37,7 @@ public class PerRequestSubmitter extends AbstractRequestSubmitter {
                     buildHttpRequest(entry, endpointUri),
                     HttpResponse.BodyHandlers.ofString())
                 .exceptionally(ex -> {
-                    // TODO This will be executed on a ForJoinPool Thread... refactor this someday.
+                    // TODO This will be executed on a ForkJoinPool Thread... refactor this someday.
                     log.error("Request fatally failed because of an exception", ex);
                     return null;
                 })

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
@@ -1,0 +1,110 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
+import com.getindata.connectors.http.internal.utils.ThreadUtils;
+
+@Slf4j
+public class PerRequestSubmitter implements RequestSubmitter {
+
+    private static final int HTTP_CLIENT_THREAD_POOL_SIZE = 16;
+
+    public static final String DEFAULT_REQUEST_TIMEOUT_SECONDS = "30";
+
+    /**
+     * Thread pool to handle HTTP response from HTTP client.
+     */
+    private final ExecutorService publishingThreadPool;
+
+    private final int httpRequestTimeOutSeconds;
+
+    private final String[] headersAndValues;
+
+    private final HttpClient httpClient;
+
+    public PerRequestSubmitter(Properties properties, String[] headersAndValues) {
+
+        this.headersAndValues = headersAndValues;
+
+        this.publishingThreadPool =
+            Executors.newFixedThreadPool(
+                HTTP_CLIENT_THREAD_POOL_SIZE,
+                new ExecutorThreadFactory(
+                    "http-sink-client-response-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
+
+        this.httpRequestTimeOutSeconds = Integer.parseInt(
+            properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_TIMEOUT_SECONDS,
+                DEFAULT_REQUEST_TIMEOUT_SECONDS)
+        );
+
+        ExecutorService httpClientExecutor =
+            Executors.newFixedThreadPool(
+                HTTP_CLIENT_THREAD_POOL_SIZE,
+                new ExecutorThreadFactory(
+                    "http-sink-client-request-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
+
+        this.httpClient = JavaNetHttpClientFactory.createClient(properties, httpClientExecutor);
+    }
+
+    @Override
+    public List<CompletableFuture<JavaNetHttpResponseWrapper>> submit(
+            String endpointUrl,
+            List<HttpSinkRequestEntry> requestToSubmit) {
+
+        var endpointUri = URI.create(endpointUrl);
+        var responseFutures = new ArrayList<CompletableFuture<JavaNetHttpResponseWrapper>>();
+
+        for (var entry : requestToSubmit) {
+            var response = httpClient
+                .sendAsync(
+                    buildHttpRequest(entry, endpointUri),
+                    HttpResponse.BodyHandlers.ofString())
+                .exceptionally(ex -> {
+                    // TODO This will be executed on a ForJoinPool Thread... refactor this someday.
+                    log.error("Request fatally failed because of an exception", ex);
+                    return null;
+                })
+                .thenApplyAsync(
+                    res -> new JavaNetHttpResponseWrapper(entry, res),
+                    publishingThreadPool
+                );
+            responseFutures.add(response);
+        }
+        return responseFutures;
+    }
+
+    private HttpRequest buildHttpRequest(HttpSinkRequestEntry requestEntry, URI endpointUri) {
+        Builder requestBuilder = HttpRequest
+            .newBuilder()
+            .uri(endpointUri)
+            .version(Version.HTTP_1_1)
+            .timeout(Duration.ofSeconds(httpRequestTimeOutSeconds))
+            .method(requestEntry.method,
+                BodyPublishers.ofByteArray(requestEntry.element));
+
+        if (headersAndValues.length != 0) {
+            requestBuilder.headers(headersAndValues);
+        }
+
+        return requestBuilder.build();
+    }
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
@@ -1,6 +1,7 @@
 package com.getindata.connectors.http.internal.sink.httpclient;
 
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -19,8 +20,12 @@ import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 @Slf4j
 public class PerRequestSubmitter extends AbstractRequestSubmitter {
 
-    public PerRequestSubmitter(Properties properties, String[] headersAndValues) {
-        super(properties, headersAndValues);
+    public PerRequestSubmitter(
+            Properties properties,
+            String[] headersAndValues,
+            HttpClient httpClient) {
+
+        super(properties, headersAndValues, httpClient);
     }
 
     @Override

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
@@ -16,6 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 
+/**
+ * This implementation creates HTTP requests for every processed event.
+ */
 @Slf4j
 public class PerRequestSubmitter extends AbstractRequestSubmitter {
 

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
@@ -1,7 +1,6 @@
 package com.getindata.connectors.http.internal.sink.httpclient;
 
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -12,57 +11,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
-import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
-import com.getindata.connectors.http.internal.utils.JavaNetHttpClientFactory;
-import com.getindata.connectors.http.internal.utils.ThreadUtils;
 
 @Slf4j
-public class PerRequestSubmitter implements RequestSubmitter {
-
-    private static final int HTTP_CLIENT_THREAD_POOL_SIZE = 16;
-
-    public static final String DEFAULT_REQUEST_TIMEOUT_SECONDS = "30";
-
-    /**
-     * Thread pool to handle HTTP response from HTTP client.
-     */
-    private final ExecutorService publishingThreadPool;
-
-    private final int httpRequestTimeOutSeconds;
-
-    private final String[] headersAndValues;
-
-    private final HttpClient httpClient;
+public class PerRequestSubmitter extends AbstractRequestSubmitter {
 
     public PerRequestSubmitter(Properties properties, String[] headersAndValues) {
-
-        this.headersAndValues = headersAndValues;
-
-        this.publishingThreadPool =
-            Executors.newFixedThreadPool(
-                HTTP_CLIENT_THREAD_POOL_SIZE,
-                new ExecutorThreadFactory(
-                    "http-sink-client-response-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
-
-        this.httpRequestTimeOutSeconds = Integer.parseInt(
-            properties.getProperty(HttpConnectorConfigConstants.SINK_HTTP_TIMEOUT_SECONDS,
-                DEFAULT_REQUEST_TIMEOUT_SECONDS)
-        );
-
-        ExecutorService httpClientExecutor =
-            Executors.newFixedThreadPool(
-                HTTP_CLIENT_THREAD_POOL_SIZE,
-                new ExecutorThreadFactory(
-                    "http-sink-client-request-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
-
-        this.httpClient = JavaNetHttpClientFactory.createClient(properties, httpClientExecutor);
+        super(properties, headersAndValues);
     }
 
     @Override

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/RequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/RequestSubmitter.java
@@ -5,6 +5,9 @@ import java.util.concurrent.CompletableFuture;
 
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 
+/**
+ * Submits request via HTTP.
+ */
 public interface RequestSubmitter {
 
     List<CompletableFuture<JavaNetHttpResponseWrapper>> submit(

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/RequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/RequestSubmitter.java
@@ -1,0 +1,13 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+
+public interface RequestSubmitter {
+
+    List<CompletableFuture<JavaNetHttpResponseWrapper>> submit(
+        String endpointUrl,
+        List<HttpSinkRequestEntry> requestToSubmit);
+}

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/RequestSubmitterFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/RequestSubmitterFactory.java
@@ -1,0 +1,8 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.util.Properties;
+
+public interface RequestSubmitterFactory {
+
+    RequestSubmitter createSubmitter(Properties properties, String[] headersAndValues);
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
@@ -21,6 +21,7 @@ import com.getindata.connectors.http.HttpPostRequestCallback;
 import com.getindata.connectors.http.HttpSink;
 import com.getindata.connectors.http.HttpSinkBuilder;
 import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.sink.httpclient.JavaNetSinkHttpClient;
 import com.getindata.connectors.http.internal.table.SerializationSchemaElementConverter;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
@@ -79,7 +80,7 @@ public class HttpDynamicSink extends AsyncDynamicTableSink<HttpSinkRequestEntry>
 
     private final EncodingFormat<SerializationSchema<RowData>> encodingFormat;
 
-    private final HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback;
+    private final HttpPostRequestCallback<HttpRequest> httpPostRequestCallback;
 
     private final ReadableConfig tableOptions;
 
@@ -93,7 +94,7 @@ public class HttpDynamicSink extends AsyncDynamicTableSink<HttpSinkRequestEntry>
         @Nullable Long maxTimeInBufferMS,
         DataType consumedDataType,
         EncodingFormat<SerializationSchema<RowData>> encodingFormat,
-        HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback,
+        HttpPostRequestCallback<HttpRequest> httpPostRequestCallback,
         ReadableConfig tableOptions,
         Properties properties) {
         super(maxBatchSize, maxInFlightRequests, maxBufferedRequests, maxBufferSizeInBytes,
@@ -172,7 +173,7 @@ public class HttpDynamicSink extends AsyncDynamicTableSink<HttpSinkRequestEntry>
 
         private EncodingFormat<SerializationSchema<RowData>> encodingFormat;
 
-        private HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback;
+        private HttpPostRequestCallback<HttpRequest> httpPostRequestCallback;
 
         /**
          * @param tableOptions the {@link ReadableConfig} consisting of options listed in table
@@ -200,7 +201,7 @@ public class HttpDynamicSink extends AsyncDynamicTableSink<HttpSinkRequestEntry>
          * @return {@link HttpDynamicTableSinkBuilder} itself
          */
         public HttpDynamicTableSinkBuilder setHttpPostRequestCallback(
-            HttpPostRequestCallback<HttpSinkRequestEntry> httpPostRequestCallback) {
+            HttpPostRequestCallback<HttpRequest> httpPostRequestCallback) {
             this.httpPostRequestCallback = httpPostRequestCallback;
             return this;
         }

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicTableSinkFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicTableSinkFactory.java
@@ -12,7 +12,7 @@ import org.apache.flink.table.factories.FactoryUtil;
 
 import com.getindata.connectors.http.HttpPostRequestCallbackFactory;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
-import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.utils.ConfigUtils;
 import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.*;
 
@@ -43,7 +43,7 @@ public class HttpDynamicTableSinkFactory extends AsyncDynamicTableSinkFactory {
             new AsyncSinkConfigurationValidator(tableOptions).getValidatedConfigurations();
 
         // generics type erasure, so we have to do an unchecked cast
-        final HttpPostRequestCallbackFactory<HttpSinkRequestEntry> postRequestCallbackFactory =
+        final HttpPostRequestCallbackFactory<HttpRequest> postRequestCallbackFactory =
             FactoryUtil.discoverFactory(
                 context.getClassLoader(),
                 HttpPostRequestCallbackFactory.class,  // generics type erasure

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallback.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallback.java
@@ -3,11 +3,12 @@ package com.getindata.connectors.http.internal.table.sink;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
 import com.getindata.connectors.http.HttpPostRequestCallback;
-import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.utils.ConfigUtils;
 
 /**
@@ -18,28 +19,32 @@ import com.getindata.connectors.http.internal.utils.ConfigUtils;
  * the {@link HttpDynamicSink}.
  */
 @Slf4j
-public class Slf4jHttpPostRequestCallback implements HttpPostRequestCallback<HttpSinkRequestEntry> {
+public class Slf4jHttpPostRequestCallback implements HttpPostRequestCallback<HttpRequest> {
 
     @Override
     public void call(
         HttpResponse<String> response,
-        HttpSinkRequestEntry requestEntry,
+        HttpRequest requestEntry,
         String endpointUrl,
         Map<String, String> headerMap) {
+
+        String reqeustBody = requestEntry.getElements().stream()
+            .map(element -> new String(element, StandardCharsets.UTF_8))
+            .collect(Collectors.joining());
 
         if (response == null) {
             log.info(
                 "Got response for a request.\n  Request:\n    " +
                 "Method: {}\n    Body: {}\n  Response: null",
-                requestEntry.method,
-                new String(requestEntry.element, StandardCharsets.UTF_8)
+                requestEntry.getMethod(),
+                reqeustBody
             );
         } else {
             log.info(
                 "Got response for a request.\n  Request:\n    " +
                 "Method: {}\n    Body: {}\n  Response: {}\n    Body: {}",
                 requestEntry.method,
-                new String(requestEntry.element, StandardCharsets.UTF_8),
+                reqeustBody,
                 response,
                 response.body().replaceAll(ConfigUtils.UNIVERSAL_NEW_LINE_REGEXP, "")
             );

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallback.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallback.java
@@ -28,7 +28,7 @@ public class Slf4jHttpPostRequestCallback implements HttpPostRequestCallback<Htt
         String endpointUrl,
         Map<String, String> headerMap) {
 
-        String reqeustBody = requestEntry.getElements().stream()
+        String requestBody = requestEntry.getElements().stream()
             .map(element -> new String(element, StandardCharsets.UTF_8))
             .collect(Collectors.joining());
 
@@ -37,14 +37,14 @@ public class Slf4jHttpPostRequestCallback implements HttpPostRequestCallback<Htt
                 "Got response for a request.\n  Request:\n    " +
                 "Method: {}\n    Body: {}\n  Response: null",
                 requestEntry.getMethod(),
-                reqeustBody
+                requestBody
             );
         } else {
             log.info(
                 "Got response for a request.\n  Request:\n    " +
                 "Method: {}\n    Body: {}\n  Response: {}\n    Body: {}",
                 requestEntry.method,
-                reqeustBody,
+                requestBody,
                 response,
                 response.body().replaceAll(ConfigUtils.UNIVERSAL_NEW_LINE_REGEXP, "")
             );

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallbackFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/Slf4jHttpPostRequestCallbackFactory.java
@@ -7,18 +7,18 @@ import org.apache.flink.configuration.ConfigOption;
 
 import com.getindata.connectors.http.HttpPostRequestCallback;
 import com.getindata.connectors.http.HttpPostRequestCallbackFactory;
-import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 
 /**
  * Factory for creating {@link Slf4jHttpPostRequestCallback}.
  */
 public class Slf4jHttpPostRequestCallbackFactory
-    implements HttpPostRequestCallbackFactory<HttpSinkRequestEntry> {
+    implements HttpPostRequestCallbackFactory<HttpRequest> {
 
     public static final String IDENTIFIER = "slf4j-logger";
 
     @Override
-    public HttpPostRequestCallback<HttpSinkRequestEntry> createHttpPostRequestCallback() {
+    public HttpPostRequestCallback<HttpRequest> createHttpPostRequestCallback() {
         return new Slf4jHttpPostRequestCallback();
     }
 

--- a/src/main/java/com/getindata/connectors/http/internal/utils/JavaNetHttpClientFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/utils/JavaNetHttpClientFactory.java
@@ -88,11 +88,9 @@ public class JavaNetHttpClientFactory {
         String clientPrivateKey = properties
             .getProperty(HttpConnectorConfigConstants.CLIENT_PRIVATE_KEY, "");
 
-        if (serverTrustedCerts.length > 0) {
-            for (String cert : serverTrustedCerts) {
-                if (!StringUtils.isNullOrWhitespaceOnly(cert)) {
-                    securityContext.addCertToTrustStore(cert);
-                }
+        for (String cert : serverTrustedCerts) {
+            if (!StringUtils.isNullOrWhitespaceOnly(cert)) {
+                securityContext.addCertToTrustStore(cert);
             }
         }
 

--- a/src/test/java/com/getindata/connectors/http/TestPostRequestCallbackFactory.java
+++ b/src/test/java/com/getindata/connectors/http/TestPostRequestCallbackFactory.java
@@ -5,15 +5,14 @@ import java.util.Set;
 
 import org.apache.flink.configuration.ConfigOption;
 
-import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 
-public class TestPostRequestCallbackFactory
-    implements HttpPostRequestCallbackFactory<HttpSinkRequestEntry> {
+public class TestPostRequestCallbackFactory implements HttpPostRequestCallbackFactory<HttpRequest> {
 
     public static final String TEST_POST_REQUEST_CALLBACK_IDENT = "test-request-callback";
 
     @Override
-    public HttpPostRequestCallback<HttpSinkRequestEntry> createHttpPostRequestCallback() {
+    public HttpPostRequestCallback<HttpRequest> createHttpPostRequestCallback() {
         return new HttpPostRequestCallbackFactoryTest.TestPostRequestCallback();
     }
 

--- a/src/test/java/com/getindata/connectors/http/internal/HttpsConnectionTestBase.java
+++ b/src/test/java/com/getindata/connectors/http/internal/HttpsConnectionTestBase.java
@@ -5,7 +5,7 @@ import java.util.Properties;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
 import com.getindata.connectors.http.HttpPostRequestCallback;
-import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallback;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 
@@ -31,7 +31,7 @@ public abstract class HttpsConnectionTestBase {
 
     protected HeaderPreprocessor headerPreprocessor;
 
-    protected HttpPostRequestCallback<HttpSinkRequestEntry> postRequestCallback =
+    protected HttpPostRequestCallback<HttpRequest> postRequestCallback =
         new Slf4jHttpPostRequestCallback();
 
     public void setUp() {

--- a/src/test/java/com/getindata/connectors/http/internal/HttpsConnectionTestBase.java
+++ b/src/test/java/com/getindata/connectors/http/internal/HttpsConnectionTestBase.java
@@ -4,6 +4,9 @@ import java.util.Properties;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import com.getindata.connectors.http.HttpPostRequestCallback;
+import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+import com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallback;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 
 public abstract class HttpsConnectionTestBase {
@@ -27,6 +30,9 @@ public abstract class HttpsConnectionTestBase {
     protected Properties properties;
 
     protected HeaderPreprocessor headerPreprocessor;
+
+    protected HttpPostRequestCallback<HttpSinkRequestEntry> postRequestCallback =
+        new Slf4jHttpPostRequestCallback();
 
     public void setUp() {
         this.properties = new Properties();

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
@@ -23,8 +23,11 @@ public class HttpSinkBuilderTest {
             IllegalArgumentException.class,
             () -> HttpSink.<String>builder().setElementConverter(ELEMENT_CONVERTER)
                 .setSinkHttpClientBuilder(
-                    (properties, httpPostRequestCallback, headerPreprocessor)
-                        -> new MockHttpClient())
+                    (
+                        properties,
+                        httpPostRequestCallback,
+                        headerPreprocessor,
+                        requestSubmitterFactory) -> new MockHttpClient())
                 .setEndpointUrl("")
                 .build()
         );
@@ -37,8 +40,11 @@ public class HttpSinkBuilderTest {
             () -> HttpSink.<String>builder()
                 .setElementConverter(ELEMENT_CONVERTER)
                 .setSinkHttpClientBuilder(
-                    (properties, httpPostRequestCallback, headerPreprocessor)
-                        -> new MockHttpClient())
+                    (
+                        properties,
+                        httpPostRequestCallback,
+                        headerPreprocessor,
+                        requestSubmitterFactory) -> new MockHttpClient())
                 .build()
         );
     }

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
@@ -21,8 +21,7 @@ public class HttpSinkBuilderTest {
     public void testEmptyUrl() {
         assertThrows(
             IllegalArgumentException.class,
-            () -> HttpSink.<String>builder()
-                .setElementConverter(ELEMENT_CONVERTER)
+            () -> HttpSink.<String>builder().setElementConverter(ELEMENT_CONVERTER)
                 .setSinkHttpClientBuilder(
                     (properties, httpPostRequestCallback, headerPreprocessor)
                         -> new MockHttpClient())

--- a/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitterFactoryTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitterFactoryTest.java
@@ -1,0 +1,86 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.getindata.connectors.http.internal.config.ConfigException;
+import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+
+class BatchRequestSubmitterFactoryTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    public void shouldThrowIfInvalidDefaultSize(int invalidArgument) {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new BatchRequestSubmitterFactory(invalidArgument)
+        );
+    }
+
+    @Test
+    public void shouldCreateSubmitterWithDefaultBatchSize() {
+
+        int defaultBatchSize = 10;
+        BatchRequestSubmitter submitter = new BatchRequestSubmitterFactory(defaultBatchSize)
+            .createSubmitter(new Properties(), new String[0]);
+
+        assertThat(submitter.getBatchSize()).isEqualTo(defaultBatchSize);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "2"})
+    public void shouldCreateSubmitterWithCustomBatchSize(String batchSize) {
+
+        Properties properties = new Properties();
+        properties.setProperty(
+            HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+            batchSize
+        );
+
+        BatchRequestSubmitter submitter = new BatchRequestSubmitterFactory(10)
+            .createSubmitter(properties, new String[0]);
+
+        assertThat(submitter.getBatchSize()).isEqualTo(Integer.valueOf(batchSize));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-1"})
+    public void shouldThrowIfBatchSizeToSmall(String invalidBatchSize) {
+
+        Properties properties = new Properties();
+        properties.setProperty(
+            HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+            invalidBatchSize
+        );
+
+        BatchRequestSubmitterFactory factory = new BatchRequestSubmitterFactory(10);
+
+        assertThrows(
+            ConfigException.class,
+            () -> factory.createSubmitter(properties, new String[0])
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.1", "2,2", "hello"})
+    public void shouldThrowIfInvalidBatchSize(String invalidBatchSize) {
+
+        Properties properties = new Properties();
+        properties.setProperty(
+            HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+            invalidBatchSize
+        );
+
+        BatchRequestSubmitterFactory factory = new BatchRequestSubmitterFactory(10);
+
+        assertThrows(
+            ConfigException.class,
+            () -> factory.createSubmitter(properties, new String[0])
+        );
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitterTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitterTest.java
@@ -1,0 +1,96 @@
+package com.getindata.connectors.http.internal.sink.httpclient;
+
+import java.net.http.HttpClient;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
+import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
+
+@ExtendWith(MockitoExtension.class)
+class BatchRequestSubmitterTest {
+
+    @Mock
+    private HttpClient mockHttpClient;
+
+    @ParameterizedTest
+    @CsvSource(value = {"50, 1", "5, 1", "3, 2", "2, 3", "1, 5"})
+    public void submitBatches(int batchSize, int expectedNumberOfBatchRequests) {
+
+        Properties properties = new Properties();
+        properties.setProperty(
+            HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+            String.valueOf(batchSize)
+        );
+
+        when(mockHttpClient.sendAsync(any(), any())).thenReturn(new CompletableFuture<>());
+
+        BatchRequestSubmitter submitter = new BatchRequestSubmitter(
+            properties,
+            new String[0],
+            mockHttpClient
+        );
+
+        submitter.submit(
+            "http://hello.pl",
+            IntStream.range(0, 5)
+                .mapToObj(val -> new HttpSinkRequestEntry("PUT", new byte[0]))
+                .collect(Collectors.toList())
+        );
+
+        verify(mockHttpClient, times(expectedNumberOfBatchRequests)).sendAsync(any(), any());
+    }
+
+    private static Stream<Arguments> httpRequestMethods() {
+        return Stream.of(
+            Arguments.of(List.of("PUT", "PUT", "PUT", "PUT", "POST"), 2),
+            Arguments.of(List.of("PUT", "PUT", "PUT", "POST", "PUT"), 3),
+            Arguments.of(List.of("POST", "PUT", "POST", "POST", "PUT"), 4)
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("httpRequestMethods")
+    public void shouldSplitBatchPerHttpMethod(
+            List<String> httpMethods,
+            int expectedNumberOfBatchRequests) {
+
+        Properties properties = new Properties();
+        properties.setProperty(
+            HttpConnectorConfigConstants.SINK_HTTP_BATCH_REQUEST_SIZE,
+            String.valueOf(50)
+        );
+
+        when(mockHttpClient.sendAsync(any(), any())).thenReturn(new CompletableFuture<>());
+
+        BatchRequestSubmitter submitter = new BatchRequestSubmitter(
+            properties,
+            new String[0],
+            mockHttpClient
+        );
+
+        submitter.submit(
+            "http://hello.pl",
+            httpMethods.stream()
+                .map(method -> new HttpSinkRequestEntry(method, new byte[0]))
+                .collect(Collectors.toList())
+        );
+
+        verify(mockHttpClient, times(expectedNumberOfBatchRequests)).sendAsync(any(), any());
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientConnectionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientConnectionTest.java
@@ -205,9 +205,15 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
             clientPrivateKey.getAbsolutePath()
         );
 
+        // TODO HTTP-42 add test for PerRequest submitter
         assertThrows(
             RuntimeException.class,
-            () -> new JavaNetSinkHttpClient(properties, headerPreprocessor)
+            () -> new JavaNetSinkHttpClient(
+                properties,
+                postRequestCallback,
+                headerPreprocessor,
+                new BatchRequestSubmitterFactory(50)
+            )
         );
     }
 
@@ -237,7 +243,12 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
 
         try {
             JavaNetSinkHttpClient client =
-                new JavaNetSinkHttpClient(properties, headerPreprocessor);
+                new JavaNetSinkHttpClient(
+                    properties,
+                    postRequestCallback,
+                    headerPreprocessor,
+                    // TODO HTTP-42 add test for PerRequest submitter
+                    new BatchRequestSubmitterFactory(50));
             HttpSinkRequestEntry requestEntry = new HttpSinkRequestEntry("GET", new byte[0]);
             SinkHttpClientResponse response =
                 client.putRequests(

--- a/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientConnectionTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientConnectionTest.java
@@ -16,6 +16,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.getindata.connectors.http.internal.HttpsConnectionTestBase;
@@ -25,9 +26,15 @@ import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 
 class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
 
+    private RequestSubmitterFactory perRequestSubmitterFactory;
+
+    private RequestSubmitterFactory batchRequestSubmitterFactory;
+
     @BeforeEach
     public void setUp() {
         super.setUp();
+        this.perRequestSubmitterFactory = new PerRequestRequestSubmitterFactory();
+        this.batchRequestSubmitterFactory = new BatchRequestSubmitterFactory(50);
     }
 
     @AfterEach
@@ -42,7 +49,17 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
         wireMockServer.start();
         mockEndPoint(wireMockServer);
 
-        testSinkClientForConnection(new Properties(), "http://localhost:", SERVER_PORT);
+        testSinkClientForConnection(
+            new Properties(),
+            "http://localhost:",
+            SERVER_PORT,
+            perRequestSubmitterFactory);
+
+        testSinkClientForConnection(
+            new Properties(),
+            "http://localhost:",
+            SERVER_PORT,
+            batchRequestSubmitterFactory);
     }
 
     @Test
@@ -63,7 +80,17 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
 
         properties.setProperty(HttpConnectorConfigConstants.ALLOW_SELF_SIGNED, "true");
 
-        testSinkClientForConnection(properties, "https://localhost:", HTTPS_SERVER_PORT);
+        testSinkClientForConnection(
+            properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            perRequestSubmitterFactory);
+
+        testSinkClientForConnection(
+            properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            batchRequestSubmitterFactory);
     }
 
     @ParameterizedTest
@@ -89,7 +116,19 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
             trustedCert.getAbsolutePath()
         );
 
-        testSinkClientForConnection(properties, "https://localhost:", HTTPS_SERVER_PORT);
+        testSinkClientForConnection(
+            properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            perRequestSubmitterFactory
+        );
+
+        testSinkClientForConnection(
+            properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            batchRequestSubmitterFactory
+        );
     }
 
     @ParameterizedTest
@@ -130,7 +169,19 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
             clientPrivateKey.getAbsolutePath()
         );
 
-        testSinkClientForConnection(properties, "https://localhost:", HTTPS_SERVER_PORT);
+        testSinkClientForConnection(
+            properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            perRequestSubmitterFactory
+        );
+
+        testSinkClientForConnection(
+            properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            batchRequestSubmitterFactory
+        );
     }
 
     @Test
@@ -173,7 +224,18 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
             serverTrustedCert.getAbsolutePath()
         );
 
-        testSinkClientForConnection(properties, "https://localhost:", HTTPS_SERVER_PORT);
+        testSinkClientForConnection(
+            properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            perRequestSubmitterFactory
+        );
+
+        testSinkClientForConnection(properties,
+            "https://localhost:",
+            HTTPS_SERVER_PORT,
+            batchRequestSubmitterFactory
+        );
     }
 
 
@@ -205,16 +267,26 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
             clientPrivateKey.getAbsolutePath()
         );
 
-        // TODO HTTP-42 add test for PerRequest submitter
-        assertThrows(
-            RuntimeException.class,
-            () -> new JavaNetSinkHttpClient(
-                properties,
-                postRequestCallback,
-                headerPreprocessor,
-                new BatchRequestSubmitterFactory(50)
-            )
-        );
+        assertAll(() -> {
+            assertThrows(
+                RuntimeException.class,
+                () -> new JavaNetSinkHttpClient(
+                    properties,
+                    postRequestCallback,
+                    headerPreprocessor,
+                    perRequestSubmitterFactory
+                )
+            );
+            assertThrows(
+                RuntimeException.class,
+                () -> new JavaNetSinkHttpClient(
+                    properties,
+                    postRequestCallback,
+                    headerPreprocessor,
+                    batchRequestSubmitterFactory
+                )
+            );
+        });
     }
 
     @ParameterizedTest
@@ -233,13 +305,26 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
             authorizationHeaderValue
         );
 
-        testSinkClientForConnection(properties, "http://localhost:", SERVER_PORT);
+        testSinkClientForConnection(
+            properties,
+            "http://localhost:",
+            SERVER_PORT,
+            perRequestSubmitterFactory
+        );
+
+        testSinkClientForConnection(
+            properties,
+            "http://localhost:",
+            SERVER_PORT,
+            batchRequestSubmitterFactory
+        );
     }
 
     private void testSinkClientForConnection(
             Properties properties,
             String endpointUrl,
-            int httpsServerPort) {
+            int httpsServerPort,
+            RequestSubmitterFactory requestSubmitterFactory) {
 
         try {
             JavaNetSinkHttpClient client =
@@ -247,8 +332,7 @@ class JavaNetSinkHttpClientConnectionTest extends HttpsConnectionTestBase {
                     properties,
                     postRequestCallback,
                     headerPreprocessor,
-                    // TODO HTTP-42 add test for PerRequest submitter
-                    new BatchRequestSubmitterFactory(50));
+                    requestSubmitterFactory);
             HttpSinkRequestEntry requestEntry = new HttpSinkRequestEntry("GET", new byte[0]);
             SinkHttpClientResponse response =
                 client.putRequests(

--- a/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClientTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 import com.getindata.connectors.http.HttpPostRequestCallback;
 import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
-import com.getindata.connectors.http.internal.sink.HttpSinkRequestEntry;
 import com.getindata.connectors.http.internal.table.sink.Slf4jHttpPostRequestCallback;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
 import static com.getindata.connectors.http.TestHelper.assertPropertyArray;
@@ -39,7 +38,7 @@ class JavaNetSinkHttpClientTest {
 
     protected HeaderPreprocessor headerPreprocessor;
 
-    protected HttpPostRequestCallback<HttpSinkRequestEntry> postRequestCallback;
+    protected HttpPostRequestCallback<HttpRequest> postRequestCallback;
 
     @AfterAll
     public static void afterAll() {

--- a/src/test/java/com/getindata/connectors/http/internal/table/sink/BatchRequestHttpDynamicSinkInsertTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/sink/BatchRequestHttpDynamicSinkInsertTest.java
@@ -73,7 +73,7 @@ public class BatchRequestHttpDynamicSinkInsertTest {
         wireMockServer.stop();
     }
 
-    private static Stream<Arguments> reqeustBatch() {
+    private static Stream<Arguments> requestBatch() {
         return Stream.of(
             Arguments.of(50, "allInOneBatch.txt"),
             Arguments.of(5, "allInOneBatch.txt"),
@@ -84,7 +84,7 @@ public class BatchRequestHttpDynamicSinkInsertTest {
     }
 
     @ParameterizedTest
-    @MethodSource("reqeustBatch")
+    @MethodSource("requestBatch")
     public void testHttpDynamicSinkDefaultPost(int requestBatchSize, String expectedRequests)
             throws Exception {
 
@@ -129,7 +129,7 @@ public class BatchRequestHttpDynamicSinkInsertTest {
     }
 
     @ParameterizedTest
-    @MethodSource("reqeustBatch")
+    @MethodSource("requestBatch")
     public void testHttpDynamicSinkPut(int requestBatchSize, String expectedRequests)
             throws Exception {
 

--- a/src/test/java/com/getindata/connectors/http/internal/table/sink/PerRequestHttpDynamicSinkInsertTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/sink/PerRequestHttpDynamicSinkInsertTest.java
@@ -1,0 +1,309 @@
+package com.getindata.connectors.http.internal.table.sink;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PerRequestHttpDynamicSinkInsertTest {
+
+    private static final int SERVER_PORT = 9090;
+
+    private static final int HTTPS_SERVER_PORT = 8443;
+
+    private static final String CERTS_PATH = "src/test/resources/security/certs/";
+
+    private static final String SERVER_KEYSTORE_PATH =
+        "src/test/resources/security/certs/serverKeyStore.jks";
+
+    private static final String SERVER_TRUSTSTORE_PATH =
+        "src/test/resources/security/certs/serverTrustStore.jks";
+
+    protected StreamExecutionEnvironment env;
+
+    protected StreamTableEnvironment tEnv;
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    public void setup() {
+        File keyStoreFile = new File(SERVER_KEYSTORE_PATH);
+        File trustStoreFile = new File(SERVER_TRUSTSTORE_PATH);
+
+        this.wireMockServer = new WireMockServer(options()
+            .port(SERVER_PORT)
+            .httpsPort(HTTPS_SERVER_PORT)
+            .keystorePath(keyStoreFile.getAbsolutePath())
+            .keystorePassword("password")
+            .keyManagerPassword("password")
+            .needClientAuth(true)
+            .trustStorePath(trustStoreFile.getAbsolutePath())
+            .trustStorePassword("password")
+        );
+
+        wireMockServer.start();
+
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    public void testHttpDynamicSinkDefaultPost() throws Exception {
+        wireMockServer.stubFor(any(urlPathEqualTo("/myendpoint")).willReturn(ok()));
+        String contentTypeHeaderValue = "application/json";
+
+        final String createTable =
+            String.format(
+                "CREATE TABLE http (\n"
+                    + "  id bigint,\n"
+                    + "  first_name string,\n"
+                    + "  last_name string,\n"
+                    + "  gender string,\n"
+                    + "  stock string,\n"
+                    + "  currency string,\n"
+                    + "  tx_date timestamp(3)\n"
+                    + ") with (\n"
+                    + "  'connector' = '%s',\n"
+                    + "  'url' = '%s',\n"
+                    + "  'format' = 'json',\n"
+                    + "  'gid.connector.http.sink.writer.request.mode' = 'single',\n"
+                    + "  'gid.connector.http.sink.header.Content-Type' = '%s'\n"
+                    + ")",
+                HttpDynamicTableSinkFactory.IDENTIFIER,
+                "http://localhost:" + SERVER_PORT + "/myendpoint",
+                contentTypeHeaderValue
+            );
+
+        tEnv.executeSql(createTable);
+
+        final String insert = "INSERT INTO http\n"
+            + "VALUES (1, 'Ninette', 'Clee', 'Female', 'CDZI', 'RUB', "
+            + "TIMESTAMP '2021-08-24 15:22:59')";
+        tEnv.executeSql(insert).await();
+
+        var postedRequests =
+            wireMockServer.findAll(anyRequestedFor(urlPathEqualTo("/myendpoint")));
+        assertEquals(1, postedRequests.size());
+
+        var request = postedRequests.get(0);
+        assertEquals(
+            "{\"id\":1,\"first_name\":\"Ninette\",\"last_name\":\"Clee\","
+                + "\"gender\":\"Female\",\"stock\":\"CDZI\",\"currency\":\"RUB\","
+                + "\"tx_date\":\"2021-08-24 15:22:59\"}",
+            request.getBodyAsString()
+        );
+        assertEquals(RequestMethod.POST, request.getMethod());
+        assertEquals(contentTypeHeaderValue, request.getHeader("Content-Type"));
+    }
+
+    @Test
+    public void testHttpDynamicSinkPut() throws Exception {
+        wireMockServer.stubFor(any(urlPathEqualTo("/myendpoint")).willReturn(ok()));
+        String contentTypeHeaderValue = "application/json";
+
+        final String createTable =
+            String.format(
+                "CREATE TABLE http (\n"
+                    + "  id bigint,\n"
+                    + "  first_name string,\n"
+                    + "  last_name string,\n"
+                    + "  gender string,\n"
+                    + "  stock string,\n"
+                    + "  currency string,\n"
+                    + "  tx_date timestamp(3)\n"
+                    + ") with (\n"
+                    + "  'connector' = '%s',\n"
+                    + "  'url' = '%s',\n"
+                    + "  'insert-method' = 'PUT',\n"
+                    + "  'format' = 'json',\n"
+                    + "  'gid.connector.http.sink.writer.request.mode' = 'single',\n"
+                    + "  'gid.connector.http.sink.header.Content-Type' = '%s'\n"
+                    + ")",
+                HttpDynamicTableSinkFactory.IDENTIFIER,
+                "http://localhost:" + SERVER_PORT + "/myendpoint",
+                contentTypeHeaderValue
+            );
+
+        tEnv.executeSql(createTable);
+
+        final String insert = "INSERT INTO http\n"
+            + "VALUES\n"
+            + " (1, 'Ninette', 'Clee', 'Female', 'CDZI', 'RUB', TIMESTAMP '2021-08-24 15:22:59'),\n"
+            + " (2, 'Hedy', 'Hedgecock', 'Female', 'DGICA', 'CNY', "
+            + "TIMESTAMP '2021-10-24 20:53:54')";
+        tEnv.executeSql(insert).await();
+
+        var postedRequests = wireMockServer.findAll(anyRequestedFor(urlPathEqualTo("/myendpoint")));
+        assertEquals(2, postedRequests.size());
+
+        var jsonRequests = new HashSet<>(Set.of(
+            "{\"id\":1,\"first_name\":\"Ninette\",\"last_name\":\"Clee\",\"gender\":\"Female\","
+                + "\"stock\":\"CDZI\",\"currency\":\"RUB\",\"tx_date\":\"2021-08-24 15:22:59\"}",
+            "{\"id\":2,\"first_name\":\"Hedy\",\"last_name\":\"Hedgecock\",\"gender\":\"Female\","
+                + "\"stock\":\"DGICA\",\"currency\":\"CNY\",\"tx_date\":\"2021-10-24 20:53:54\"}"
+        ));
+        for (var request : postedRequests) {
+            assertEquals(RequestMethod.PUT, request.getMethod());
+            assertEquals(contentTypeHeaderValue, request.getHeader("Content-Type"));
+            assertTrue(jsonRequests.contains(request.getBodyAsString()));
+            jsonRequests.remove(request.getBodyAsString());
+        }
+    }
+
+    @Test
+    public void testHttpDynamicSinkRawFormat() throws Exception {
+        wireMockServer.stubFor(any(urlPathEqualTo("/myendpoint")).willReturn(ok()));
+        String contentTypeHeaderValue = "application/octet-stream";
+
+        final String createTable =
+            String.format(
+                "CREATE TABLE http (\n"
+                    + "  last_name string"
+                    + ") with (\n"
+                    + "  'connector' = '%s',\n"
+                    + "  'url' = '%s',\n"
+                    + "  'format' = 'raw',\n"
+                    + "  'gid.connector.http.sink.writer.request.mode' = 'single',\n"
+                    + "  'gid.connector.http.sink.header.Content-Type' = '%s'\n"
+                    + ")",
+                HttpDynamicTableSinkFactory.IDENTIFIER,
+                "http://localhost:" + SERVER_PORT + "/myendpoint",
+                contentTypeHeaderValue
+            );
+
+        tEnv.executeSql(createTable);
+
+        final String insert = "INSERT INTO http VALUES ('Clee')";
+        tEnv.executeSql(insert).await();
+
+        var postedRequests = wireMockServer.findAll(anyRequestedFor(urlPathEqualTo("/myendpoint")));
+        assertEquals(1, postedRequests.size());
+
+        var request = postedRequests.get(0);
+        assertEquals("Clee", request.getBodyAsString());
+        assertEquals(RequestMethod.POST, request.getMethod());
+        assertEquals(contentTypeHeaderValue, request.getHeader("Content-Type"));
+    }
+
+    @Test
+    public void testHttpRequestWithHeadersFromDdl()
+        throws ExecutionException, InterruptedException {
+        String originHeaderValue = "*";
+        String xContentTypeOptionsHeaderValue = "nosniff";
+        String contentTypeHeaderValue = "application/json";
+
+        wireMockServer.stubFor(any(urlPathEqualTo("/myendpoint")).willReturn(ok()));
+
+        final String createTable =
+            String.format(
+                "CREATE TABLE http (\n"
+                    + "  last_name string"
+                    + ") with (\n"
+                    + "  'connector' = '%s',\n"
+                    + "  'url' = '%s',\n"
+                    + "  'format' = 'raw',\n"
+                    + "  'gid.connector.http.sink.writer.request.mode' = 'single',\n"
+                    + "  'gid.connector.http.sink.header.Origin' = '%s',\n"
+                    + "  'gid.connector.http.sink.header.X-Content-Type-Options' = '%s',\n"
+                    + "  'gid.connector.http.sink.header.Content-Type' = '%s'\n"
+                    + ")",
+                HttpDynamicTableSinkFactory.IDENTIFIER,
+                "http://localhost:" + SERVER_PORT + "/myendpoint",
+                originHeaderValue,
+                xContentTypeOptionsHeaderValue,
+                contentTypeHeaderValue
+            );
+
+        tEnv.executeSql(createTable);
+
+        final String insert = "INSERT INTO http VALUES ('Clee')";
+        tEnv.executeSql(insert).await();
+
+        var postedRequests = wireMockServer.findAll(anyRequestedFor(urlPathEqualTo("/myendpoint")));
+        assertEquals(1, postedRequests.size());
+
+        var request = postedRequests.get(0);
+        assertEquals("Clee", request.getBodyAsString());
+        assertEquals(RequestMethod.POST, request.getMethod());
+        assertEquals(contentTypeHeaderValue, request.getHeader("Content-Type"));
+        assertEquals(originHeaderValue, request.getHeader("Origin"));
+        assertEquals(xContentTypeOptionsHeaderValue, request.getHeader("X-Content-Type-Options"));
+    }
+
+    @Test
+    public void testHttpsWithMTls() throws Exception {
+
+        File serverTrustedCert = new File(CERTS_PATH + "ca.crt");
+
+        File clientCert = new File(CERTS_PATH + "client.crt");
+        File clientPrivateKey = new File(CERTS_PATH + "clientPrivateKey.pem");
+
+        wireMockServer.stubFor(any(urlPathEqualTo("/myendpoint")).willReturn(ok()));
+        String contentTypeHeaderValue = "application/json";
+
+        final String createTable =
+            String.format(
+                "CREATE TABLE http (\n"
+                    + "  id bigint,\n"
+                    + "  first_name string,\n"
+                    + "  last_name string,\n"
+                    + "  gender string,\n"
+                    + "  stock string,\n"
+                    + "  currency string,\n"
+                    + "  tx_date timestamp(3)\n"
+                    + ") with (\n"
+                    + "  'connector' = '%s',\n"
+                    + "  'url' = '%s',\n"
+                    + "  'format' = 'json',\n"
+                    + "  'gid.connector.http.sink.writer.request.mode' = 'single',\n"
+                    + "  'gid.connector.http.sink.header.Content-Type' = '%s',\n"
+                    + "  'gid.connector.http.security.cert.server' = '%s',\n"
+                    + "  'gid.connector.http.security.cert.client' = '%s',\n"
+                    + "  'gid.connector.http.security.key.client' = '%s'\n"
+                    + ")",
+                HttpDynamicTableSinkFactory.IDENTIFIER,
+                "https://localhost:" + HTTPS_SERVER_PORT + "/myendpoint",
+                contentTypeHeaderValue,
+                serverTrustedCert.getAbsolutePath(),
+                clientCert.getAbsolutePath(),
+                clientPrivateKey.getAbsolutePath()
+            );
+
+        tEnv.executeSql(createTable);
+
+        final String insert = "INSERT INTO http\n"
+            + "VALUES (1, 'Ninette', 'Clee', 'Female', 'CDZI', 'RUB', "
+            + "TIMESTAMP '2021-08-24 15:22:59')";
+        tEnv.executeSql(insert).await();
+
+        var postedRequests =
+            wireMockServer.findAll(anyRequestedFor(urlPathEqualTo("/myendpoint")));
+        assertEquals(1, postedRequests.size());
+
+        var request = postedRequests.get(0);
+        assertEquals(
+            "{\"id\":1,\"first_name\":\"Ninette\",\"last_name\":\"Clee\","
+                + "\"gender\":\"Female\",\"stock\":\"CDZI\",\"currency\":\"RUB\","
+                + "\"tx_date\":\"2021-08-24 15:22:59\"}",
+            request.getBodyAsString()
+        );
+
+    }
+}

--- a/src/test/resources/json/sink/allInOneBatch.txt
+++ b/src/test/resources/json/sink/allInOneBatch.txt
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 1,
+    "first_name": "Ninette",
+    "last_name": "Clee",
+    "gender": "Female",
+    "stock": "CDZI",
+    "currency": "RUB",
+    "tx_date": "2021-08-24 15:22:59"
+  },
+  {
+    "id": 2,
+    "first_name": "Rob",
+    "last_name": "Zombie",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "GBP",
+    "tx_date": "2021-10-25 20:53:54"
+  },
+  {
+    "id": 3,
+    "first_name": "Adam",
+    "last_name": "Jones",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "PLN",
+    "tx_date": "2021-10-26 20:53:54"
+  },
+  {
+    "id": 4,
+    "first_name": "Danny",
+    "last_name": "Carey",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "USD",
+    "tx_date": "2021-10-27 20:53:54"
+  },
+  {
+    "id": 5,
+    "first_name": "Bob",
+    "last_name": "Dylan",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "USD",
+    "tx_date": "2021-10-28 20:53:54"
+  }
+]

--- a/src/test/resources/json/sink/fourSingleEventBatches.txt
+++ b/src/test/resources/json/sink/fourSingleEventBatches.txt
@@ -1,0 +1,60 @@
+[
+	{
+		"id": 2,
+		"first_name": "Rob",
+		"last_name": "Zombie",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "GBP",
+		"tx_date": "2021-10-25 20:53:54"
+	}
+]
+#-----#
+[
+	{
+		"id": 3,
+		"first_name": "Adam",
+		"last_name": "Jones",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "PLN",
+		"tx_date": "2021-10-26 20:53:54"
+	}
+]
+#-----#
+[
+	{
+		"id": 4,
+		"first_name": "Danny",
+		"last_name": "Carey",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "USD",
+		"tx_date": "2021-10-27 20:53:54"
+	}
+]
+#-----#
+[
+	{
+		"id": 1,
+		"first_name": "Ninette",
+		"last_name": "Clee",
+		"gender": "Female",
+		"stock": "CDZI",
+		"currency": "RUB",
+		"tx_date": "2021-08-24 15:22:59"
+	}
+]
+#-----#
+[
+	{
+		"id": 5,
+		"first_name": "Bob",
+		"last_name": "Dylan",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "USD",
+		"tx_date": "2021-10-28 20:53:54"
+	}
+]
+

--- a/src/test/resources/json/sink/threeBatches.txt
+++ b/src/test/resources/json/sink/threeBatches.txt
@@ -1,0 +1,53 @@
+[
+	{
+		"id": 1,
+		"first_name": "Ninette",
+		"last_name": "Clee",
+		"gender": "Female",
+		"stock": "CDZI",
+		"currency": "RUB",
+		"tx_date": "2021-08-24 15:22:59"
+	},
+	{
+		"id": 2,
+		"first_name": "Rob",
+		"last_name": "Zombie",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "GBP",
+		"tx_date": "2021-10-25 20:53:54"
+	}
+]
+#-----#
+[
+	{
+		"id": 3,
+		"first_name": "Adam",
+		"last_name": "Jones",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "PLN",
+		"tx_date": "2021-10-26 20:53:54"
+	},
+	{
+		"id": 4,
+		"first_name": "Danny",
+		"last_name": "Carey",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "USD",
+		"tx_date": "2021-10-27 20:53:54"
+	}
+]
+#-----#
+[
+	{
+		"id": 5,
+		"first_name": "Bob",
+		"last_name": "Dylan",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "USD",
+		"tx_date": "2021-10-28 20:53:54"
+	}
+]

--- a/src/test/resources/json/sink/twoBatches.txt
+++ b/src/test/resources/json/sink/twoBatches.txt
@@ -1,0 +1,50 @@
+[
+  {
+    "id": 4,
+    "first_name": "Danny",
+    "last_name": "Carey",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "USD",
+    "tx_date": "2021-10-27 20:53:54"
+  },
+  {
+    "id": 5,
+    "first_name": "Bob",
+    "last_name": "Dylan",
+    "gender": "Male",
+    "stock": "DGICA",
+    "currency": "USD",
+    "tx_date": "2021-10-28 20:53:54"
+  }
+]
+#-----#
+[
+	{
+		"id": 1,
+		"first_name": "Ninette",
+		"last_name": "Clee",
+		"gender": "Female",
+		"stock": "CDZI",
+		"currency": "RUB",
+		"tx_date": "2021-08-24 15:22:59"
+	},
+	{
+		"id": 2,
+		"first_name": "Rob",
+		"last_name": "Zombie",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "GBP",
+		"tx_date": "2021-10-25 20:53:54"
+	},
+	{
+		"id": 3,
+		"first_name": "Adam",
+		"last_name": "Jones",
+		"gender": "Male",
+		"stock": "DGICA",
+		"currency": "PLN",
+		"tx_date": "2021-10-26 20:53:54"
+	}
+]


### PR DESCRIPTION
#### Description
This PR adds support for submitting events by HTTP Sink in batch mode, meaning that body of one HTTP PUT/POST requests will contain data for many processed events. 

The data is represented as Json array, like so:

```
[
  {
    "id": 1,
    "first_name": "Ninette",
    "last_name": "Clee",
    "gender": "Female",
    "stock": "CDZI",
    "currency": "RUB",
    "tx_date": "2021-08-24 15:22:59"
  },
  {
    "id": 2,
    "first_name": "Rob",
    "last_name": "Zombie",
    "gender": "Male",
    "stock": "DGICA",
    "currency": "GBP",
    "tx_date": "2021-10-25 20:53:54"
  },
  {
    "id": 3,
    "first_name": "Adam",
    "last_name": "Jones",
    "gender": "Male",
    "stock": "DGICA",
    "currency": "PLN",
    "tx_date": "2021-10-26 20:53:54"
  }
]
```

This is a breaking change. Users will have to adapt to it or restore "single mode" by setting:
`gid.connector.http.sink.writer.request.mode = single`

Resolves https://github.com/getindata/flink-http-connector/issues/42

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
