### PR TITLE
HTTP-78 Support for optional query parameters for body-based requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
     transformation for Basic Authentication (base64, addition of "Basic " prefix).
     If not specified, defaults to `'false'`.
 
+### Changed
+
+-   Changed API for `LookupQueryCreator`. The method `createLookupQuery` no longer returns a String but a
+    [LookupQueryInfo](src/main/java/com/getindata/connectors/http/internal/table/lookup/LookupQueryInfo.java)
+    Any custom implementation of this interface that aims to provide body-based request is able to provide
+    the lookup query as the payload and an optional formatted string representing the query parameters.
+
 ## [0.11.0] - 2023-11-20
 
 ## [0.10.0] - 2023-07-05

--- a/src/main/java/com/getindata/connectors/http/LookupQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/LookupQueryCreator.java
@@ -4,9 +4,12 @@ import java.io.Serializable;
 
 import org.apache.flink.table.data.RowData;
 
+import com.getindata.connectors.http.internal.table.lookup.LookupQueryInfo;
+
 /**
  * An interface for a creator of a lookup query in the Http Lookup Source (e.g., the query that
- * gets appended to the URI in GET request).
+ * gets appended as query parameters to the URI in GET request or supplied as the payload of a
+ * body-based request along with optional query parameters).
  *
  * <p>One can customize how those queries are built by implementing {@link LookupQueryCreator} and
  * {@link LookupQueryCreatorFactory}.
@@ -20,5 +23,5 @@ public interface LookupQueryCreator extends Serializable {
      * @param lookupDataRow a {@link RowData} containing request parameters.
      * @return a lookup query.
      */
-    String createLookupQuery(RowData lookupDataRow);
+    LookupQueryInfo createLookupQuery(RowData lookupDataRow);
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/BodyBasedRequestFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/BodyBasedRequestFactory.java
@@ -37,14 +37,14 @@ public class BodyBasedRequestFactory extends RequestFactoryBase {
      * Method for preparing {@link HttpRequest.Builder} for REST request that sends their parameters
      * in request body, for example PUT or POST methods
      *
-     * @param lookupQuery lookup query used for request body.
+     * @param lookupQueryInfo lookup query info used for request body.
      * @return {@link HttpRequest.Builder} for given lookupQuery.
      */
     @Override
-    protected Builder setUpRequestMethod(String lookupQuery) {
+    protected Builder setUpRequestMethod(LookupQueryInfo lookupQueryInfo) {
         return HttpRequest.newBuilder()
-            .uri(constructGetUri())
-            .method(methodName, BodyPublishers.ofString(lookupQuery))
+            .uri(constructBodyBasedUri(lookupQueryInfo))
+            .method(methodName, BodyPublishers.ofString(lookupQueryInfo.getLookupQuery()))
             .timeout(Duration.ofSeconds(this.httpRequestTimeOutSeconds));
     }
 
@@ -53,9 +53,15 @@ public class BodyBasedRequestFactory extends RequestFactoryBase {
         return log;
     }
 
-    private URI constructGetUri() {
+    URI constructBodyBasedUri(LookupQueryInfo lookupQueryInfo) {
+        StringBuilder resolvedUrl = new StringBuilder(baseUrl);
+        if (lookupQueryInfo.hasBodyBasedUrlQueryParameters()) {
+            resolvedUrl.append(baseUrl.contains("?") ? "&" : "?")
+                       .append(lookupQueryInfo.getBodyBasedUrlQueryParameters());
+        }
+
         try {
-            return new URIBuilder(baseUrl).build();
+            return new URIBuilder(resolvedUrl.toString()).build();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/GetRequestFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/GetRequestFactory.java
@@ -33,25 +33,36 @@ public class GetRequestFactory extends RequestFactoryBase {
     }
 
     /**
-     * Method for preparing {@link HttpRequest.Builder} for REST GET request, where lookupQuery
-     * is used as query parameters for example:
+     * Method for preparing {@link HttpRequest.Builder} for REST GET request, where lookupQueryInfo
+     * is used as query parameters for GET requests, for example:
      * <pre>
      *     http:localhost:8080/service?id=1
      * </pre>
-     * @param lookupQuery lookup query used for request query parameters.
+     * or as payload for body-based requests with optional parameters, for example:
+     * <pre>
+     *     http:localhost:8080/service?id=1
+     *     body payload: { "uid": 2 }
+     * </pre>
+     * @param lookupQueryInfo lookup query info used for request query parameters.
      * @return {@link HttpRequest.Builder} for given GET lookupQuery
      */
     @Override
-    protected Builder setUpRequestMethod(String lookupQuery) {
+    protected Builder setUpRequestMethod(LookupQueryInfo lookupQueryInfo) {
         return HttpRequest.newBuilder()
-            .uri(constructGetUri(lookupQuery))
+            .uri(constructGetUri(lookupQueryInfo))
             .GET()
             .timeout(Duration.ofSeconds(this.httpRequestTimeOutSeconds));
     }
 
-    private URI constructGetUri(String lookupQuery) {
+    URI constructGetUri(LookupQueryInfo lookupQueryInfo) {
+        StringBuilder resolvedUrl = new StringBuilder(baseUrl);
+        if (lookupQueryInfo.hasLookupQuery()) {
+            resolvedUrl.append(baseUrl.contains("?") ? "&" : "?")
+                       .append(lookupQueryInfo.getLookupQuery());
+        }
+
         try {
-            return new URIBuilder(baseUrl + "?" + lookupQuery).build();
+            return new URIBuilder(resolvedUrl.toString()).build();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupSourceRequestEntry.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupSourceRequestEntry.java
@@ -23,11 +23,10 @@ public class HttpLookupSourceRequestEntry {
      * represent a request body, for example a Json string when PUT/POST requests method was used,
      * or it can represent a query parameters if GET method was used.
      */
-    private final String lookupQuery;
+    private final LookupQueryInfo lookupQueryInfo;
 
-    public HttpLookupSourceRequestEntry(HttpRequest httpRequest, String lookupQuery) {
-
+    public HttpLookupSourceRequestEntry(HttpRequest httpRequest, LookupQueryInfo lookupQueryInfo) {
         this.httpRequest = httpRequest;
-        this.lookupQuery = lookupQuery;
+        this.lookupQueryInfo = lookupQueryInfo;
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/LookupQueryInfo.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/LookupQueryInfo.java
@@ -1,0 +1,57 @@
+package com.getindata.connectors.http.internal.table.lookup;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import com.getindata.connectors.http.internal.utils.uri.NameValuePair;
+import com.getindata.connectors.http.internal.utils.uri.URLEncodedUtils;
+
+/**
+ * Holds the lookup query for an HTTP request.
+ * The {@code  lookupQuery} either contain the query parameters for a GET operation
+ * or the payload of a body-based request.
+ * The {@code bodyBasedUrlQueryParams} contains the optional query parameters of a
+ * body-based request in addition to its payload supplied with {@code  lookupQuery}.
+ */
+@ToString
+public class LookupQueryInfo implements Serializable {
+    @Getter
+    private final String lookupQuery;
+
+    private final Map<String, String> bodyBasedUrlQueryParams;
+
+    public LookupQueryInfo(String lookupQuery) {
+        this(lookupQuery, null);
+    }
+
+    public LookupQueryInfo(String lookupQuery, Map<String, String> bodyBasedUrlQueryParams) {
+        this.lookupQuery =
+                lookupQuery == null ? "" : lookupQuery;
+        this.bodyBasedUrlQueryParams =
+                bodyBasedUrlQueryParams == null ? Collections.emptyMap() : bodyBasedUrlQueryParams;
+    }
+
+    public String getBodyBasedUrlQueryParameters() {
+        return URLEncodedUtils.format(
+                bodyBasedUrlQueryParams
+                        .entrySet()
+                        .stream()
+                        .map(entry -> new NameValuePair(entry.getKey(), entry.getValue()))
+                        .collect(Collectors.toList()),
+                StandardCharsets.UTF_8);
+    }
+
+    public boolean hasLookupQuery() {
+        return !lookupQuery.isBlank();
+    }
+    public boolean hasBodyBasedUrlQueryParameters() {
+        return !bodyBasedUrlQueryParams.isEmpty();
+    }
+
+}

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/RequestFactoryBase.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/RequestFactoryBase.java
@@ -61,16 +61,16 @@ public abstract class RequestFactoryBase implements HttpRequestFactory {
     @Override
     public HttpLookupSourceRequestEntry buildLookupRequest(RowData lookupRow) {
 
-        String lookupQuery = lookupQueryCreator.createLookupQuery(lookupRow);
-        getLogger().debug("Created Http lookup query: " + lookupQuery);
+        LookupQueryInfo lookupQueryInfo = lookupQueryCreator.createLookupQuery(lookupRow);
+        getLogger().debug("Created Http lookup query: " + lookupQueryInfo);
 
-        Builder requestBuilder = setUpRequestMethod(lookupQuery);
+        Builder requestBuilder = setUpRequestMethod(lookupQueryInfo);
 
         if (headersAndValues.length != 0) {
             requestBuilder.headers(headersAndValues);
         }
 
-        return new HttpLookupSourceRequestEntry(requestBuilder.build(), lookupQuery);
+        return new HttpLookupSourceRequestEntry(requestBuilder.build(), lookupQueryInfo);
     }
 
     protected abstract Logger getLogger();
@@ -80,7 +80,7 @@ public abstract class RequestFactoryBase implements HttpRequestFactory {
      * @param lookupQuery lookup query used for request query parameters or body.
      * @return {@link HttpRequest.Builder} for given lookupQuery.
      */
-    protected abstract Builder setUpRequestMethod(String lookupQuery);
+    protected abstract Builder setUpRequestMethod(LookupQueryInfo lookupQuery);
 
     @VisibleForTesting
     String[] getHeadersAndValues() {

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/Slf4JHttpLookupPostRequestCallback.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/Slf4JHttpLookupPostRequestCallback.java
@@ -49,7 +49,7 @@ public class Slf4JHttpLookupPostRequestCallback
                 httpRequest.uri().toString(),
                 httpRequest.method(),
                 headers,
-                requestEntry.getLookupQuery()
+                requestEntry.getLookupQueryInfo()
             );
         } else {
             log.info(
@@ -58,7 +58,7 @@ public class Slf4JHttpLookupPostRequestCallback
                 httpRequest.uri().toString(),
                 httpRequest.method(),
                 headers,
-                requestEntry.getLookupQuery(),
+                requestEntry.getLookupQueryInfo(),
                 response,
                 response.body().replaceAll(ConfigUtils.UNIVERSAL_NEW_LINE_REGEXP, "")
             );

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreator.java
@@ -7,6 +7,7 @@ import org.apache.flink.table.data.RowData;
 
 import com.getindata.connectors.http.LookupArg;
 import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.internal.table.lookup.LookupQueryInfo;
 import com.getindata.connectors.http.internal.table.lookup.LookupRow;
 
 /**
@@ -35,14 +36,15 @@ public class ElasticSearchLiteQueryCreator implements LookupQueryCreator {
     }
 
     @Override
-    public String createLookupQuery(RowData lookupDataRow) {
-
+    public LookupQueryInfo createLookupQuery(RowData lookupDataRow) {
         Collection<LookupArg> lookupArgs = lookupRow.convertToLookupArgs(lookupDataRow);
 
         var luceneQuery = lookupArgs.stream()
             .map(ElasticSearchLiteQueryCreator::processLookupArg)
             .collect(Collectors.joining(ENCODED_SPACE + "AND" + ENCODED_SPACE));
 
-        return luceneQuery.isEmpty() ? "" : ("q=" + luceneQuery);
+        String lookupQuery = luceneQuery.isEmpty() ? "" : ("q=" + luceneQuery);
+
+        return new LookupQueryInfo(lookupQuery);
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreator.java
@@ -8,6 +8,7 @@ import org.apache.flink.table.data.RowData;
 
 import com.getindata.connectors.http.LookupArg;
 import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.internal.table.lookup.LookupQueryInfo;
 import com.getindata.connectors.http.internal.table.lookup.LookupRow;
 import com.getindata.connectors.http.internal.utils.uri.NameValuePair;
 import com.getindata.connectors.http.internal.utils.uri.URLEncodedUtils;
@@ -25,14 +26,17 @@ public class GenericGetQueryCreator implements LookupQueryCreator {
     }
 
     @Override
-    public String createLookupQuery(RowData lookupDataRow) {
+    public LookupQueryInfo createLookupQuery(RowData lookupDataRow) {
 
         Collection<LookupArg> lookupArgs = lookupRow.convertToLookupArgs(lookupDataRow);
 
-        return URLEncodedUtils.format(
-            lookupArgs.stream()
-                .map(arg -> new NameValuePair(arg.getArgName(), arg.getArgValue()))
-                .collect(Collectors.toList()),
-            StandardCharsets.UTF_8);
+        String lookupQuery =
+            URLEncodedUtils.format(
+                lookupArgs.stream()
+                        .map(arg -> new NameValuePair(arg.getArgName(), arg.getArgValue()))
+                        .collect(Collectors.toList()),
+                StandardCharsets.UTF_8);
+
+        return new LookupQueryInfo(lookupQuery);
     }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreator.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreator.java
@@ -7,6 +7,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import com.getindata.connectors.http.LookupQueryCreator;
+import com.getindata.connectors.http.internal.table.lookup.LookupQueryInfo;
 import com.getindata.connectors.http.internal.utils.SerializationSchemaUtils;
 
 /**
@@ -33,9 +34,12 @@ public class GenericJsonQueryCreator implements LookupQueryCreator {
      * @return Json string created from lookupDataRow argument.
      */
     @Override
-    public String createLookupQuery(RowData lookupDataRow) {
+    public LookupQueryInfo createLookupQuery(RowData lookupDataRow) {
         checkOpened();
-        return new String(jsonSerialization.serialize(lookupDataRow), StandardCharsets.UTF_8);
+        String lookupQuery =
+                new String(jsonSerialization.serialize(lookupDataRow), StandardCharsets.UTF_8);
+
+        return new LookupQueryInfo(lookupQuery);
     }
 
     private void checkOpened() {

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/LookupQueryInfoTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/LookupQueryInfoTest.java
@@ -1,0 +1,44 @@
+package com.getindata.connectors.http.internal.table.lookup;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LookupQueryInfoTest {
+
+    private LookupQueryInfo lookupQueryInfo;
+
+    @Test
+    public void testConfiguredLookupQuery() {
+        String lookupQuery = "{\"param1\": \"value1\"}";
+        Map<String, String> bodyBasedUrlQueryParameters = Map.of("key1", "value1");
+
+        lookupQueryInfo = new LookupQueryInfo(lookupQuery, bodyBasedUrlQueryParameters);
+
+        assertThat(lookupQueryInfo.hasLookupQuery()).isTrue();
+        assertThat(lookupQueryInfo.getLookupQuery()).isEqualTo(lookupQuery);
+        assertThat(lookupQueryInfo.hasBodyBasedUrlQueryParameters()).isTrue();
+        assertThat(lookupQueryInfo.getBodyBasedUrlQueryParameters()).isEqualTo("key1=value1");
+    }
+    @Test
+    public void testEmptyLookupQueryInfo() {
+        lookupQueryInfo = new LookupQueryInfo(null, null);
+
+        assertThat(lookupQueryInfo.hasLookupQuery()).isFalse();
+        assertThat(lookupQueryInfo.hasBodyBasedUrlQueryParameters()).isFalse();
+        assertThat(lookupQueryInfo.getLookupQuery()).isEqualTo("");
+        assertThat(lookupQueryInfo.getBodyBasedUrlQueryParameters()).isEqualTo("");
+    }
+
+    @Test
+    public void testBodyBasedUrlQueryParams() {
+        Map<String, String> bodyBasedUrlQueryParameters = Map.of("key1", "value1");
+
+        lookupQueryInfo = new LookupQueryInfo(null, bodyBasedUrlQueryParameters);
+
+        assertThat(lookupQueryInfo.hasLookupQuery()).isFalse();
+        assertThat(lookupQueryInfo.hasBodyBasedUrlQueryParameters()).isTrue();
+        assertThat(lookupQueryInfo.getBodyBasedUrlQueryParameters()).isEqualTo("key1=value1");
+    }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorTest.java
@@ -36,7 +36,8 @@ public class ElasticSearchLiteQueryCreatorTest {
         var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
 
         // THEN
-        assertThat(createdQuery).isEqualTo("q=key1:%22val1%22");
+        assertThat(createdQuery.getLookupQuery()).isEqualTo("q=key1:%22val1%22");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters()).isEmpty();
     }
 
     @Test
@@ -68,7 +69,8 @@ public class ElasticSearchLiteQueryCreatorTest {
         var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
 
         // THEN
-        assertThat(createdQuery).isEqualTo("q=key1:%2210%22");
+        assertThat(createdQuery.getLookupQuery()).isEqualTo("q=key1:%2210%22");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters()).isEmpty();
     }
 
     @Test
@@ -110,7 +112,9 @@ public class ElasticSearchLiteQueryCreatorTest {
         var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
 
         // THEN
-        assertThat(createdQuery)
-            .isEqualTo("q=key1:%22val1%22%20AND%20key2:%22val2%22%20AND%20key3:%223%22");
+        assertThat(createdQuery.getLookupQuery())
+                .isEqualTo("q=key1:%22val1%22%20AND%20key2:%22val2%22%20AND%20key3:%223%22");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters())
+                .isEmpty();
     }
 }

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreatorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericGetQueryCreatorTest.java
@@ -37,7 +37,8 @@ public class GenericGetQueryCreatorTest {
         var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
 
         // THEN
-        assertThat(createdQuery).isEqualTo("key1=val1");
+        assertThat(createdQuery.getLookupQuery()).isEqualTo("key1=val1");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters()).isEmpty();
     }
 
     @Test
@@ -69,7 +70,8 @@ public class GenericGetQueryCreatorTest {
         var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
 
         // THEN
-        assertThat(createdQuery).isEqualTo("key1=10");
+        assertThat(createdQuery.getLookupQuery()).isEqualTo("key1=10");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters()).isEmpty();
     }
 
     @Test
@@ -111,7 +113,8 @@ public class GenericGetQueryCreatorTest {
         var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
 
         // THEN
-        assertThat(createdQuery).isEqualTo("key1=val1&key2=val2&key3=3");
+        assertThat(createdQuery.getLookupQuery()).isEqualTo("key1=val1&key2=val2&key3=3");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters()).isEmpty();
     }
 
     @Test
@@ -172,6 +175,7 @@ public class GenericGetQueryCreatorTest {
         var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
 
         // THEN
-        assertThat(createdQuery).isEqualTo("col1=val1&col2=val2&col3=val3");
+        assertThat(createdQuery.getLookupQuery()).isEqualTo("col1=val1&col2=val2&col3=val3");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters()).isEmpty();
     }
 }

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.getindata.connectors.http.internal.table.lookup.LookupQueryInfo;
 import static com.getindata.connectors.http.internal.table.lookup.HttpLookupTableSourceFactory.row;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,7 +52,8 @@ class GenericJsonQueryCreatorTest {
         row.setField(0, 11);
         row.setField(1, StringData.fromString("myUuid"));
 
-        String lookupQuery = this.jsonQueryCreator.createLookupQuery(row);
-        assertThat(lookupQuery).isEqualTo("{\"id\":11,\"uuid\":\"myUuid\"}");
+        LookupQueryInfo lookupQuery = this.jsonQueryCreator.createLookupQuery(row);
+        assertThat(lookupQuery.getBodyBasedUrlQueryParameters().isEmpty());
+        assertThat(lookupQuery.getLookupQuery()).isEqualTo("{\"id\":11,\"uuid\":\"myUuid\"}");
     }
 }


### PR DESCRIPTION
Support for optional query parameters for body-based requests

#### Description

As [documented](https://github.com/getindata/flink-http-connector/blob/main/README.md#http-tablelookup-source), the connector currently create a lookup query from the HTTP TableLookup Source to build either:
- a query parameter list in case of a HTTP GET request
- a body payload in case of a HTTP body-based request

There is no way to change this behaviour with custom factories.

Modification:

- Change the signature of createLookupQuery(RowData lookupDataRow) in interface `LookupQueryCreator` so that it returns a class `LookupQueryInfo` holding:
   - the lookup query
   - the optional body-based query parameters

- Adapt the creation of the URIs in the constructions of HTTP requests to retrieve information from the class `LookupQueryInfo`.

With these changes, any custom implementation of this interface that aims to provide body-based request is able to provide the lookup query as the payload and an optional formatted string representing the query parameters.

Resolves #78 

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
