### PR TITLE
HTTP-83 Support SQL queries with project pushdown after a lookup join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+-   Added support for using the result of a lookup join operation in a subsequent select query that adds
+    or removes columns (project pushdown operation).
+
 ###  Changed
 
 -   Changed  [LookupQueryInfo](src/main/java/com/getindata/connectors/http/internal/table/lookup/LookupQueryInfo.java)

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpLookupTableSource.java
@@ -8,6 +8,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.AsyncTableFunctionProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -38,7 +39,7 @@ import static com.getindata.connectors.http.internal.table.lookup.HttpLookupTabl
 public class HttpLookupTableSource
     implements LookupTableSource, SupportsProjectionPushDown, SupportsLimitPushDown {
 
-    private final DataType physicalRowDataType;
+    private DataType physicalRowDataType;
 
     private final HttpLookupConfig lookupConfig;
 
@@ -56,6 +57,11 @@ public class HttpLookupTableSource
         this.lookupConfig = lookupConfig;
         this.decodingFormat = decodingFormat;
         this.dynamicTableFactoryContext = dynamicTablecontext;
+    }
+
+    @Override
+    public void applyProjection(int[][] projectedFields, DataType producedDataType) {
+        physicalRowDataType = Projection.of(projectedFields).project(physicalRowDataType);
     }
 
     @Override
@@ -127,7 +133,7 @@ public class HttpLookupTableSource
 
     @Override
     public boolean supportsNestedProjection() {
-        return false;
+        return true;
     }
 
     private PollingClientFactory<RowData> createPollingClientFactory(


### PR DESCRIPTION
#### Description

Ability to support SQL queries that add or remove columns on the result of a lookup join query.

Resolves #83 

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
