### PR TITLE
HTTP-96 Fix logging code in JavaNetHttpPollingClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed issue in the logging code of the `JavaNetHttpPollingClient` which prevents showing the status code and response body when the log level is configured at DEBUG (or lower) level.
+
 ## [0.14.0] - 2024-05-10
 
 ### Added

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/JavaNetHttpPollingClient.java
@@ -97,8 +97,8 @@ public class JavaNetHttpPollingClient implements PollingClient<RowData> {
         String responseBody = response.body();
         int statusCode = response.statusCode();
 
-        log.debug("Received status code [%s] for RestTableSource request " +
-                        "with Server response body [%s] ", statusCode, responseBody);
+        log.debug(String.format("Received status code [%s] for RestTableSource request " +
+                        "with Server response body [%s] ", statusCode, responseBody));
 
         if (notErrorCodeAndNotEmptyBody(responseBody, statusCode)) {
             return Optional.ofNullable(responseBodyDecoder.deserialize(responseBody.getBytes()));


### PR DESCRIPTION
#### Description

Resolves [#96](https://github.com/getindata/flink-http-connector/issues/96).


---

As there are no tests specifically for the logs, the validation of the PR is done manually as follows:

1. Set the DEBUG level in https://github.com/getindata/flink-http-connector/blob/main/src/test/resources/log4j2-test.properties#L19
2. `mvn clean test -Dtest=JavaNetHttpPollingClientConnectionTest`

=> the log contains:
```
Received status code [201] for RestTableSource request with Server response body [{
  "id": "COUNTER", [...] ]
```

Without the fix, it is:
```
Received status code [%s] for RestTableSource request with Server response body [%s]
```

##### PR Checklist
- [ ] Tests added (N/A)
- [x] [Changelog](CHANGELOG.md) updated 
