### PR TITLE
HTTP-119 - Fix bug where default Java TrustStore was not used when no cert-related properties were used.

### DIFF
--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/ElasticSearchLiteQueryCreatorTest.java
@@ -19,6 +19,24 @@ import static com.getindata.connectors.http.internal.table.lookup.HttpLookupTabl
 public class ElasticSearchLiteQueryCreatorTest {
 
     @Test
+    public void testWithEmptyLookup() {
+
+        // GIVEN
+        LookupRow lookupRow = new LookupRow();
+        lookupRow.setLookupPhysicalRowDataType(DataTypes.STRING());
+
+        GenericRowData lookupDataRow = GenericRowData.of(StringData.fromString("val1"));
+
+        // WHEN
+        var queryCreator = new ElasticSearchLiteQueryCreator(lookupRow);
+        var createdQuery = queryCreator.createLookupQuery(lookupDataRow);
+
+        // THEN
+        assertThat(createdQuery.getLookupQuery()).isEqualTo("");
+        assertThat(createdQuery.getBodyBasedUrlQueryParameters()).isEmpty();
+    }
+
+    @Test
     public void testQueryCreationForSingleQueryStringParam() {
 
         // GIVEN

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorTest.java
@@ -52,6 +52,23 @@ class GenericJsonQueryCreatorTest {
         row.setField(0, 11);
         row.setField(1, StringData.fromString("myUuid"));
 
+        this.jsonQueryCreator.createLookupQuery(row);
+        LookupQueryInfo lookupQuery = this.jsonQueryCreator.createLookupQuery(row);
+        assertThat(lookupQuery.getBodyBasedUrlQueryParameters().isEmpty());
+        assertThat(lookupQuery.getLookupQuery()).isEqualTo("{\"id\":11,\"uuid\":\"myUuid\"}");
+    }
+
+    @Test
+    public void shouldSerializeToJsonTwice() {
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, 11);
+        row.setField(1, StringData.fromString("myUuid"));
+
+        this.jsonQueryCreator.createLookupQuery(row);
+
+        // Call createLookupQuery two times
+        // to check that serialization schema is not opened Two times.
+        this.jsonQueryCreator.createLookupQuery(row);
         LookupQueryInfo lookupQuery = this.jsonQueryCreator.createLookupQuery(row);
         assertThat(lookupQuery.getBodyBasedUrlQueryParameters().isEmpty());
         assertThat(lookupQuery.getLookupQuery()).isEqualTo("{\"id\":11,\"uuid\":\"myUuid\"}");

--- a/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/QueryFormatAwareConfigurationTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/lookup/querycreators/QueryFormatAwareConfigurationTest.java
@@ -1,0 +1,38 @@
+package com.getindata.connectors.http.internal.table.lookup.querycreators;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryFormatAwareConfigurationTest {
+
+    private static final ConfigOption<String> configOption = ConfigOptions.key("key")
+        .stringType()
+        .noDefaultValue();
+
+    @Test
+    public void testWithDot() {
+        QueryFormatAwareConfiguration queryConfig = new QueryFormatAwareConfiguration(
+            "prefix.", Configuration.fromMap(Collections.singletonMap("prefix.key", "val"))
+        );
+
+        Optional<String> optional = queryConfig.getOptional(configOption);
+        assertThat(optional.get()).isEqualTo("val");
+    }
+
+    @Test
+    public void testWithoutDot() {
+        QueryFormatAwareConfiguration queryConfig = new QueryFormatAwareConfiguration(
+            "prefix", Configuration.fromMap(Collections.singletonMap("prefix.key", "val"))
+        );
+
+        Optional<String> optional = queryConfig.getOptional(configOption);
+        assertThat(optional.get()).isEqualTo("val");
+    }
+
+}


### PR DESCRIPTION
#### Description

Fix bug where default Java TrustStore was not used when no cert-related properties were used.

Resolves [Public certificates should not have to be supplied as they should be picked up from the jvm](https://github.com/getindata/flink-http-connector/issues/119)

##### PR Checklist
- [x] Tests added

