### PR TITLE
HTTP-121 Ensure SerializationSchema is used in thread-safe way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 -   Fixed issue in the logging code of the `JavaNetHttpPollingClient` which prevents showing the status code and response body when the log level is configured at DEBUG (or lower) level.
+-   Ensured SerializationSchema is used in thread-safe way.
 
 ## [0.14.0] - 2024-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Added support for OIDC Bearer tokens.
 
+### Fixed
+
+-   Ensured SerializationSchema is used in thread-safe way.
+
 ## [0.15.0] - 2024-07-30
 
 ### Added
@@ -15,7 +19,6 @@
 ### Fixed
 
 -   Fixed issue in the logging code of the `JavaNetHttpPollingClient` which prevents showing the status code and response body when the log level is configured at DEBUG (or lower) level.
--   Ensured SerializationSchema is used in thread-safe way.
 
 ## [0.14.0] - 2024-05-10
 

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorFactory.java
@@ -16,6 +16,7 @@ import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.LookupQueryCreatorFactory;
 import com.getindata.connectors.http.internal.table.lookup.LookupRow;
 import com.getindata.connectors.http.internal.utils.SynchronizedSerializationSchema;
+import static com.getindata.connectors.http.internal.table.lookup.HttpLookupConnectorOptions.ASYNC_POLLING;
 import static com.getindata.connectors.http.internal.table.lookup.HttpLookupConnectorOptions.LOOKUP_REQUEST_FORMAT;
 
 /**
@@ -48,8 +49,14 @@ public class GenericJsonQueryCreatorFactory implements LookupQueryCreatorFactory
             queryFormatAwareConfiguration
         );
 
-        SerializationSchema<RowData> serializationSchema = new SynchronizedSerializationSchema<>(
-            encoder.createRuntimeEncoder(null, lookupRow.getLookupPhysicalRowDataType()));
+        final SerializationSchema<RowData> serializationSchema;
+        if (readableConfig.get(ASYNC_POLLING)) {
+            serializationSchema = new SynchronizedSerializationSchema<>(
+                encoder.createRuntimeEncoder(null, lookupRow.getLookupPhysicalRowDataType()));
+        } else {
+            serializationSchema =
+                encoder.createRuntimeEncoder(null, lookupRow.getLookupPhysicalRowDataType());
+        }
 
         return new GenericJsonQueryCreator(serializationSchema);
     }

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorFactory.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/querycreators/GenericJsonQueryCreatorFactory.java
@@ -15,6 +15,7 @@ import org.apache.flink.table.factories.SerializationFormatFactory;
 import com.getindata.connectors.http.LookupQueryCreator;
 import com.getindata.connectors.http.LookupQueryCreatorFactory;
 import com.getindata.connectors.http.internal.table.lookup.LookupRow;
+import com.getindata.connectors.http.internal.utils.SynchronizedSerializationSchema;
 import static com.getindata.connectors.http.internal.table.lookup.HttpLookupConnectorOptions.LOOKUP_REQUEST_FORMAT;
 
 /**
@@ -47,8 +48,8 @@ public class GenericJsonQueryCreatorFactory implements LookupQueryCreatorFactory
             queryFormatAwareConfiguration
         );
 
-        SerializationSchema<RowData> serializationSchema =
-            encoder.createRuntimeEncoder(null, lookupRow.getLookupPhysicalRowDataType());
+        SerializationSchema<RowData> serializationSchema = new SynchronizedSerializationSchema<>(
+            encoder.createRuntimeEncoder(null, lookupRow.getLookupPhysicalRowDataType()));
 
         return new GenericJsonQueryCreator(serializationSchema);
     }

--- a/src/main/java/com/getindata/connectors/http/internal/utils/SynchronizedSerializationSchema.java
+++ b/src/main/java/com/getindata/connectors/http/internal/utils/SynchronizedSerializationSchema.java
@@ -1,0 +1,35 @@
+package com.getindata.connectors.http.internal.utils;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+
+/**
+ * Decorator which ensures that underlying SerializationSchema is called in thread-safe way.
+ *
+ * @param <T> type
+ */
+public class SynchronizedSerializationSchema<T> implements SerializationSchema<T> {
+
+    private final SerializationSchema<T> delegate;
+
+    public SynchronizedSerializationSchema(SerializationSchema<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        doOpen(context);
+    }
+
+    private synchronized void doOpen(InitializationContext context) throws Exception {
+        this.delegate.open(context);
+    }
+
+    @Override
+    public byte[] serialize(T element) {
+        return syncSerialize(element);
+    }
+
+    private synchronized byte[] syncSerialize(T element) {
+        return delegate.serialize(element);
+    }
+}


### PR DESCRIPTION
#### Description

Async lookup queries may return incorrect results because `org.apache.flink.formats.json.JsonRowDataSerializationSchema` is not thread-safe. In this PR I introduce a temporary fix, which ensures that SerializationSchema is used in thread-safe way. In long-term we should refactor the code so that serialization can be safely run in parallel.

Resolves `HTTP-121`.

##### PR Checklist
- [ ] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
