### PR TITLE
Fix adding coverage to PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,11 @@ jobs:
 
       - name: Add coverage to PR
         id: jacoco
-        uses: madrapps/jacoco-report@v1.2
+        uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: ${{ github.workspace }}/target/site/jacoco/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60
         if: startsWith(matrix.flink, '1.18') && github.event.pull_request.head.repo.fork == false
+        continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,3 @@ jobs:
           min-coverage-overall: 40
           min-coverage-changed-files: 60
         if: startsWith(matrix.flink, '1.18') && github.event.pull_request.head.repo.fork == false
-        continue-on-error: true

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ under the License.
     <assertj.core.version>3.21.0</assertj.core.version>
     <mockito.version>4.0.0</mockito.version>
     <wiremock.version>2.27.2</wiremock.version>
-    <jacoco.plugin.version>0.8.7</jacoco.plugin.version>
+    <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
     <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
     <mockito-inline.version>4.6.1</mockito-inline.version>
   </properties>
@@ -298,7 +298,7 @@ under the License.
         <version>3.0.0-M5</version>
         <configuration>
           <!-- argLine needed for Flink 1.16 and 1.17 or there are unit test errors-->
-          <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+          <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
#### Description

Step "Add coverage to PR" fails with the following error:
```
Error: ENOENT: no such file or directory, open '/home/runner/work/flink-http-connector/flink-http-connector/target/site/jacoco/jacoco.xml'
```

Adding `${argLine}` as below solves the issue.
```
<argLine>${argLine} ...</argLine>
```

