### PR TITLE
HTTP138 ignore Eclipse files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 /.idea/
 .idea
+.vscode
+.classpath
+.gitignore.swp
+.project
+.settings
 target
 bin
 /flink.http.connector.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   ignore Eclipse files in .gitignore
+
 ## [0.17.0] - 2024-11-28
 
 ### Added


### PR DESCRIPTION
#### Description

HTTP138 ignore Eclipse files in .gitignore

Resolves `HTTP138`

##### PR Checklist
- [n/a] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
