### PR TITLE
HTTP103 support Flink 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flink: [ "1.16.3", "1.17.2", "1.18.1"]
+        flink: ["1.18.1", "1.19.1", "1.20.0"]
     steps:
       - uses: actions/checkout@v3
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test JavaDoc
         run: mvn $MAVEN_CLI_OPTS $JAVA_ADDITIONAL_OPTS javadoc:javadoc
-        if: startsWith(matrix.flink, '1.18')
+        if: startsWith(matrix.flink, '1.20')
 
       - name: Add coverage to PR
         id: jacoco
@@ -48,4 +48,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60
-        if: startsWith(matrix.flink, '1.18') && github.event.pull_request.head.repo.fork == false
+        if: startsWith(matrix.flink, '1.20') && github.event.pull_request.head.repo.fork == false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
--   ignore Eclipse files in .gitignore
+-   Ignore Eclipse files in .gitignore
+-   Support Flink 1.20
 
 ## [0.17.0] - 2024-11-28
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ In case of updating http-connector please see [Breaking changes](#breaking-chang
 ## Prerequisites
 * Java 11
 * Maven 3
-* Flink 1.16+
+* Flink 1.18+. Recommended Flink 1.20.* 
+
+
 
 ## Runtime dependencies
 This connector has few Flink's runtime dependencies, that are expected to be provided.

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
     <!-- IMPORTANT: If you update Flink, remember to update link to its docs in maven-javadoc-plugin <links>
          section, omitting the patch part (so for 1.15.0 use 1.15). -->
 
-    <flink.version>1.16.3</flink.version>
+    <flink.version>1.18.1</flink.version>
 
     <target.java.version>11</target.java.version>
     <scala.binary.version>2.12</scala.binary.version>
@@ -303,10 +303,6 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
-        <configuration>
-          <!-- argLine needed for Flink 1.16 and 1.17 or there are unit test errors-->
-          <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
#### Description

Support Flink 1.20. Bumping up the level at which we build from Flink 1.16 to 1.18

Resolves `HTTP103`

##### PR Checklist
- [n/a] Tests added
- [x ] [Changelog](CHANGELOG.md) updated 
