### PR TITLE
Add missing permission in prepare_release_branch

### DIFF
--- a/.github/workflows/prepare_release_branch.yml
+++ b/.github/workflows/prepare_release_branch.yml
@@ -16,6 +16,11 @@ on:
 jobs:
   prepare-branch:
     runs-on: ubuntu-latest
+
+    permissions: # Permissions to create a new branch and a new PR.
+      contents: write
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
#### Description

This PR resolves issue with missing permissions in github workflows.

```
remote: Permission to getindata/flink-http-connector.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/getindata/flink-http-connector/': The requested URL returned error: 403
```
