### PR TITLE
HTTP-177 Add HTTP 2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added http 2 support.
+
 ## [0.22.0] - 2025-10-03
 
 -   Added ability to continue on error, introducing new metadata columns and new configuration option

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The goal for HTTP TableLookup connector was to use it in Flink SQL statement as 
  
 Currently, HTTP source connector supports only Lookup Joins (TableLookup) [1] in Table/SQL API.
 `HttpSink` supports both Streaming API (when using [HttpSink](src/main/java/com/getindata/connectors/http/internal/sink/HttpSink.java) built using [HttpSinkBuilder](src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilder.java)) and the Table API (using connector created in [HttpDynamicTableSinkFactory](src/main/java/com/getindata/connectors/http/internal/table/HttpDynamicTableSinkFactory.java)). 
+Note that the connector will work with both http 1.1 and http 2 endpoints.
 
 ## Updating the connector
 In case of updating http-connector please see [Breaking changes](#breaking-changes) section.

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/BatchRequestSubmitter.java
@@ -124,7 +124,7 @@ public class BatchRequestSubmitter extends AbstractRequestSubmitter {
             Builder requestBuilder = java.net.http.HttpRequest
                 .newBuilder()
                 .uri(endpointUri)
-                .version(Version.HTTP_1_1)
+                .version(Version.HTTP_2)
                 .timeout(Duration.ofSeconds(httpRequestTimeOutSeconds))
                 .method(method, publisher);
 

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/PerRequestSubmitter.java
@@ -62,7 +62,7 @@ public class PerRequestSubmitter extends AbstractRequestSubmitter {
         Builder requestBuilder = java.net.http.HttpRequest
             .newBuilder()
             .uri(endpointUri)
-            .version(Version.HTTP_1_1)
+            .version(Version.HTTP_2)
             .timeout(Duration.ofSeconds(httpRequestTimeOutSeconds))
             .method(requestEntry.method,
                 BodyPublishers.ofByteArray(requestEntry.element));


### PR DESCRIPTION
#### Description
This PR adds HTTP 2 support. The http client has been change to use HTTP_2 rather than HTTP_1.1. If the implmentaiton does not support http 2 is will revert to http 1.1 as before. 

WireMock does not support http2 so I could not add unit tests for it. I have manually tested that HTTP 1.1 servers and http 2 server both work. 

Resolves `HTTP177`

##### PR Checklist
- [n/a] Tests added
- [ Y [Changelog](CHANGELOG.md) updated 
