### PR TITLE
HTTP182: Add retry logic with delivery guarantees, retry all failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Fixed http sink NEP issue when flink job restore from checkpoint.
+- Added HTTP Sink request retries with delivery guarantee support (`sink.delivery-guarantee`).
 
 -   Simplify the implementation of deserialize change added in the last release and add proper testing. 
 -   HttpPostRequestCallback adds open and close methods

--- a/README.md
+++ b/README.md
@@ -508,8 +508,8 @@ By default all 400 and 500 response codes will be interpreted as error code.
 
 #### Retries and delivery guarantee
 HTTP Sink supports automatic retries when `sink.delivery-guarantee` is set to `at-least-once`. Failed requests will be automatically retried based on the configured status codes.
-- When `sink.delivery-guarantee` is `at-least-once`: Failed requests are retried automatically using AIMD (Additive Increase Multiplicative Decrease) rate limiting strategy.
-- When `sink.delivery-guarantee` is `none` (default): Failed requests are logged but not retried.
+- When `sink.delivery-guarantee` is `at-least-once` (default): Failed requests are retried automatically.
+- When `sink.delivery-guarantee` is `none`: Failed requests are logged but not retried.
 
 This behavior can be changed by using below properties in table definition (DDL) or passing it via `setProperty' method from Sink's builder. The property name are:
 - `gid.connector.http.sink.error.code` used to defined HTTP status code value that should be treated as error for example 404.
@@ -692,7 +692,7 @@ Notes:
 | gid.connector.http.logging.level                        | optional | Logging levels for HTTP content. Valid values are `MIN` (the default), `REQRESPONSE` and `MAX`.                                                                                                                                                  |
 | insert-method                                           | optional | Specify which HTTP method to use in the request. The value should be set either to `POST` or `PUT`.                                                                                                                                              |
 | sink.batch.max-size                                     | optional | Maximum number of elements that may be passed in a batch to be written downstream.                                                                                                                                                               |
-| sink.delivery-guarantee                                 | optional | Defines the delivery semantic for the HTTP sink. Accepted enumerations are 'at-least-once', and 'none' (actually 'none' is the same as 'at-most-once'. 'exactly-once' semantic is not supported.                                                 |
+| sink.delivery-guarantee                                 | optional | Defines the delivery semantic for the HTTP sink. Accepted enumerations are 'at-least-once', and 'none' (actually 'none' is the same as 'at-most-once'). 'exactly-once' semantic is not supported.                                                |
 | sink.requests.max-inflight                              | optional | The maximum number of in flight requests that may exist, if any more in flight requests need to be initiated once the maximum has been reached, then it will be blocked until some have completed.                                               |
 | sink.requests.max-buffered                              | optional | Maximum number of buffered records before applying backpressure.                                                                                                                                                                                 |
 | sink.flush-buffer.size                                  | optional | The maximum size of a batch of entries that may be sent to the HTTP endpoint measured in bytes.                                                                                                                                                  |

--- a/README.md
+++ b/README.md
@@ -503,8 +503,13 @@ is provided.
 
 ## HTTP status code handler
 ### Sink table
-You can configure a list of HTTP status codes that should be treated as errors for HTTP sink table.
+You can configure HTTP status code handling for HTTP sink table and enable automatic retries with delivery guarantees.
 By default all 400 and 500 response codes will be interpreted as error code.
+
+#### Retries and delivery guarantee
+HTTP Sink supports automatic retries when `sink.delivery-guarantee` is set to `at-least-once`. Failed requests will be automatically retried based on the configured status codes.
+- When `sink.delivery-guarantee` is `at-least-once`: Failed requests are retried automatically using AIMD (Additive Increase Multiplicative Decrease) rate limiting strategy.
+- When `sink.delivery-guarantee` is `none` (default): Failed requests are logged but not retried.
 
 This behavior can be changed by using below properties in table definition (DDL) or passing it via `setProperty' method from Sink's builder. The property name are:
 - `gid.connector.http.sink.error.code` used to defined HTTP status code value that should be treated as error for example 404.
@@ -687,6 +692,7 @@ Notes:
 | gid.connector.http.logging.level                        | optional | Logging levels for HTTP content. Valid values are `MIN` (the default), `REQRESPONSE` and `MAX`.                                                                                                                                                  |
 | insert-method                                           | optional | Specify which HTTP method to use in the request. The value should be set either to `POST` or `PUT`.                                                                                                                                              |
 | sink.batch.max-size                                     | optional | Maximum number of elements that may be passed in a batch to be written downstream.                                                                                                                                                               |
+| sink.delivery-guarantee                                 | optional | Defines the delivery semantic for the HTTP sink. Accepted enumerations are 'at-least-once', and 'none' (actually 'none' is the same as 'at-most-once'. 'exactly-once' semantic is not supported.                                                 |
 | sink.requests.max-inflight                              | optional | The maximum number of in flight requests that may exist, if any more in flight requests need to be initiated once the maximum has been reached, then it will be blocked until some have completed.                                               |
 | sink.requests.max-buffered                              | optional | Maximum number of buffered records before applying backpressure.                                                                                                                                                                                 |
 | sink.flush-buffer.size                                  | optional | The maximum size of a batch of entries that may be sent to the HTTP endpoint measured in bytes.                                                                                                                                                  |
@@ -810,9 +816,6 @@ The mapping from Http Json Response to SQL table schema is done via Flink's Json
 
 ### HTTP TableLookup Source
 - Check other `//TODO`'s.
-
-### HTTP Sink
-- Make `HttpSink` retry the failed requests. Currently, it does not retry those at all, only adds their count to the `numRecordsSendErrors` metric. It should be thoroughly thought over how to do it efficiently and then implemented.
 
 ### 
 [1] https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/table/sql/queries/joins/#lookup-join

--- a/src/main/java/com/getindata/connectors/http/HttpSink.java
+++ b/src/main/java/com/getindata/connectors/http/HttpSink.java
@@ -3,6 +3,7 @@ package com.getindata.connectors.http;
 import java.util.Properties;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 
 import com.getindata.connectors.http.internal.HeaderPreprocessor;
@@ -41,6 +42,7 @@ public class HttpSink<InputT> extends HttpSinkInternal<InputT> {
             long maxBatchSizeInBytes,
             long maxTimeInBufferMS,
             long maxRecordSizeInBytes,
+            DeliveryGuarantee deliveryGuarantee,
             String endpointUrl,
             HttpPostRequestCallback<HttpRequest> httpPostRequestCallback,
             HeaderPreprocessor headerPreprocessor,
@@ -54,6 +56,7 @@ public class HttpSink<InputT> extends HttpSinkInternal<InputT> {
             maxBatchSizeInBytes,
             maxTimeInBufferMS,
             maxRecordSizeInBytes,
+            deliveryGuarantee,
             endpointUrl,
             httpPostRequestCallback,
             headerPreprocessor,

--- a/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
+++ b/src/main/java/com/getindata/connectors/http/HttpSinkBuilder.java
@@ -4,8 +4,10 @@ import java.util.Optional;
 import java.util.Properties;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.base.sink.AsyncSinkBaseBuilder;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.util.Preconditions;
 
 import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.SinkHttpClient;
@@ -71,6 +73,8 @@ public class HttpSinkBuilder<InputT> extends
 
     private final Properties properties = new Properties();
 
+    private DeliveryGuarantee deliveryGuarantee;
+
     // Mandatory field
     private String endpointUrl;
 
@@ -90,6 +94,17 @@ public class HttpSinkBuilder<InputT> extends
         this.sinkHttpClientBuilder = DEFAULT_CLIENT_BUILDER;
         this.httpPostRequestCallback = DEFAULT_POST_REQUEST_CALLBACK;
         this.headerPreprocessor = DEFAULT_HEADER_PREPROCESSOR;
+    }
+
+    /**
+     * @param deliveryGuarantee HTTP Sink delivery guarantee
+     * @return {@link HttpSinkBuilder} itself
+     */
+    public HttpSinkBuilder<InputT> setDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee) {
+        Preconditions.checkArgument(deliveryGuarantee != DeliveryGuarantee.EXACTLY_ONCE,
+            "Only at-least-once and none delivery guarantees are supported.");
+        this.deliveryGuarantee = deliveryGuarantee;
+        return this;
     }
 
     /**
@@ -181,6 +196,7 @@ public class HttpSinkBuilder<InputT> extends
             Optional.ofNullable(getMaxBatchSizeInBytes()).orElse(DEFAULT_MAX_BATCH_SIZE_IN_B),
             Optional.ofNullable(getMaxTimeInBufferMS()).orElse(DEFAULT_MAX_TIME_IN_BUFFER_MS),
             Optional.ofNullable(getMaxRecordSizeInBytes()).orElse(DEFAULT_MAX_RECORD_SIZE_IN_B),
+            Optional.ofNullable(deliveryGuarantee).orElse(DeliveryGuarantee.NONE),
             endpointUrl,
             httpPostRequestCallback,
             headerPreprocessor,

--- a/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientResponse.java
+++ b/src/main/java/com/getindata/connectors/http/internal/SinkHttpClientResponse.java
@@ -1,6 +1,7 @@
 package com.getindata.connectors.http.internal;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.Data;
 import lombok.NonNull;
@@ -11,21 +12,36 @@ import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 
 /**
  * Data class holding {@link HttpSinkRequestEntry} instances that {@link SinkHttpClient} attempted
- * to write, divided into two lists &mdash; successful and failed ones.
+ * to write.
  */
 @Data
 @ToString
 public class SinkHttpClientResponse {
 
     /**
-     * A list of successfully written requests.
+     * A list of requests along with write status.
      */
     @NonNull
-    private final List<HttpRequest> successfulRequests;
+    private final List<ResponseItem> requests;
 
-    /**
-     * A list of requests that {@link SinkHttpClient} failed to write.
-     */
-    @NonNull
-    private final List<HttpRequest> failedRequests;
+    public List<HttpRequest> getSuccessfulRequests() {
+        return requests.stream()
+                .filter(ResponseItem::isSuccessful)
+                .map(ResponseItem::getRequest)
+                .collect(Collectors.toList());
+    }
+
+    public List<HttpRequest> getFailedRequests() {
+        return requests.stream()
+                .filter(r -> !r.isSuccessful())
+                .map(ResponseItem::getRequest)
+                .collect(Collectors.toList());
+    }
+
+    @Data
+    @ToString
+    public static class ResponseItem {
+        private final HttpRequest request;
+        private final boolean successful;
+    }
 }

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
 
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.base.sink.AsyncSinkBase;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
@@ -61,6 +62,8 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
 
     private final String endpointUrl;
 
+    private final DeliveryGuarantee deliveryGuarantee;
+
     // having Builder instead of an instance of `SinkHttpClient`
     // makes it possible to serialize `HttpSink`
     private final SinkHttpClientBuilder sinkHttpClientBuilder;
@@ -79,6 +82,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
         long maxBatchSizeInBytes,
         long maxTimeInBufferMS,
         long maxRecordSizeInBytes,
+        DeliveryGuarantee deliveryGuarantee,
         String endpointUrl,
         HttpPostRequestCallback<HttpRequest> httpPostRequestCallback,
         HeaderPreprocessor headerPreprocessor,
@@ -97,6 +101,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
 
         Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(endpointUrl),
             "The endpoint URL must be set when initializing HTTP Sink.");
+        this.deliveryGuarantee = deliveryGuarantee;
         this.endpointUrl = endpointUrl;
         this.httpPostRequestCallback =
             Preconditions.checkNotNull(
@@ -128,6 +133,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
             getMaxBatchSizeInBytes(),
             getMaxTimeInBufferMS(),
             getMaxRecordSizeInBytes(),
+            deliveryGuarantee,
             endpointUrl,
             sinkHttpClientBuilder.build(
                 properties,
@@ -165,6 +171,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
             getMaxBatchSizeInBytes(),
             getMaxTimeInBufferMS(),
             getMaxRecordSizeInBytes(),
+            deliveryGuarantee,
             endpointUrl,
             sinkHttpClientBuilder.build(
                 properties,

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkWriter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkWriter.java
@@ -1,5 +1,6 @@
 package com.getindata.connectors.http.internal.sink;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriter;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
@@ -17,6 +19,7 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import com.getindata.connectors.http.internal.SinkHttpClient;
+import com.getindata.connectors.http.internal.SinkHttpClientResponse;
 import com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants;
 import com.getindata.connectors.http.internal.utils.ThreadUtils;
 
@@ -45,6 +48,8 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
 
     private final Counter numRecordsSendErrorsCounter;
 
+    private final DeliveryGuarantee deliveryGuarantee;
+
     public HttpSinkWriter(
             ElementConverter<InputT, HttpSinkRequestEntry> elementConverter,
             Sink.InitContext context,
@@ -54,6 +59,7 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
             long maxBatchSizeInBytes,
             long maxTimeInBufferMS,
             long maxRecordSizeInBytes,
+            DeliveryGuarantee deliveryGuarantee,
             String endpointUrl,
             SinkHttpClient sinkHttpClient,
             Collection<BufferedRequestState<HttpSinkRequestEntry>> bufferedRequestStates,
@@ -61,6 +67,7 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
 
         super(elementConverter, context, maxBatchSize, maxInFlightRequests, maxBufferedRequests,
             maxBatchSizeInBytes, maxTimeInBufferMS, maxRecordSizeInBytes, bufferedRequestStates);
+        this.deliveryGuarantee = deliveryGuarantee;
         this.endpointUrl = endpointUrl;
         this.sinkHttpClient = sinkHttpClient;
 
@@ -89,35 +96,63 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
         var future = sinkHttpClient.putRequests(requestEntries, endpointUrl);
         future.whenCompleteAsync((response, err) -> {
             if (err != null) {
-                int failedRequestsNumber = requestEntries.size();
-                log.error(
-                    "Http Sink fatally failed to write all {} requests",
-                    failedRequestsNumber);
-                numRecordsSendErrorsCounter.inc(failedRequestsNumber);
-
-                // TODO: Make `HttpSinkInternal` retry the failed requests.
-                //  Currently, it does not retry those at all, only adds their count
-                //  to the `numRecordsSendErrors` metric. It is due to the fact we do not have
-                //  a clear image how we want to do it, so it would be both efficient and correct.
-                //requestResult.accept(requestEntries);
+                handleFullyFailedRequest(err, requestEntries, requestResult);
             } else if (response.getFailedRequests().size() > 0) {
                 int failedRequestsNumber = response.getFailedRequests().size();
-                log.error("Http Sink failed to write and will retry {} requests",
-                    failedRequestsNumber);
                 numRecordsSendErrorsCounter.inc(failedRequestsNumber);
-
-                // TODO: Make `HttpSinkInternal` retry the failed requests. Currently,
-                //  it does not retry those at all, only adds their count to the
-                //  `numRecordsSendErrors` metric. It is due to the fact we do not have
-                //  a clear image how we want to do it, so it would be both efficient and correct.
-
-                //requestResult.accept(response.getFailedRequests());
-                //} else {
-                //requestResult.accept(Collections.emptyList());
-                //}
+                log.error("Http Sink failed to write and will retry {} requests",
+                        failedRequestsNumber);
+                handlePartiallyFailedRequest(response, requestEntries, requestResult);
+            } else {
+                requestResult.accept(Collections.emptyList());
             }
-            requestResult.accept(Collections.emptyList());
         }, sinkWriterThreadPool);
+    }
+
+    private void handleFullyFailedRequest(Throwable err,
+                                          List<HttpSinkRequestEntry> requestEntries,
+                                          Consumer<List<HttpSinkRequestEntry>> requestResult) {
+        int failedRequestsNumber = requestEntries.size();
+        numRecordsSendErrorsCounter.inc(failedRequestsNumber);
+
+        if (deliveryGuarantee == DeliveryGuarantee.AT_LEAST_ONCE) {
+            // Retry all requests.
+            log.error("Http Sink fatally failed to write and will retry {} requests", failedRequestsNumber, err);
+            requestResult.accept(requestEntries);
+        } else if (deliveryGuarantee == DeliveryGuarantee.NONE) {
+            // Do not retry failed requests.
+            log.error(
+                    "Http Sink fatally failed to write {} requests but will continue due to {} DeliveryGuarantee",
+                    failedRequestsNumber,
+                    deliveryGuarantee,
+                    err
+            );
+            requestResult.accept(Collections.emptyList());
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported delivery guarantee: " + deliveryGuarantee);
+        }
+    }
+
+    private void handlePartiallyFailedRequest(SinkHttpClientResponse response,
+                                              List<HttpSinkRequestEntry> requestEntries,
+                                              Consumer<List<HttpSinkRequestEntry>> requestResult) {
+        if (deliveryGuarantee == DeliveryGuarantee.AT_LEAST_ONCE) {
+            // Assumption: the order of response.requests is the same as requestEntries.
+            // See com.getindata.connectors.http.internal.sink.httpclient.
+            // JavaNetSinkHttpClient#putRequests where requests are submitted sequentially and
+            // then their futures are joined sequentially too.
+            List<HttpSinkRequestEntry> failedRequestEntries = new ArrayList<>();
+            for (int i = 0; i < response.getRequests().size(); ++i) {
+                if (!response.getRequests().get(i).isSuccessful()) {
+                    failedRequestEntries.add(requestEntries.get(i));
+                }
+            }
+            requestResult.accept(failedRequestEntries);
+        } else if (deliveryGuarantee == DeliveryGuarantee.NONE) {
+            // Do not retry failed requests.
+            requestResult.accept(Collections.emptyList());
+        }
     }
 
     @Override

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSink.java
@@ -25,6 +25,7 @@ import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
 import com.getindata.connectors.http.internal.sink.httpclient.JavaNetSinkHttpClient;
 import com.getindata.connectors.http.internal.table.SerializationSchemaElementConverter;
 import com.getindata.connectors.http.internal.utils.HttpHeaderUtils;
+import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.DELIVERY_GUARANTEE;
 import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.INSERT_METHOD;
 import static com.getindata.connectors.http.internal.table.sink.HttpDynamicSinkConnectorOptions.URL;
 
@@ -125,6 +126,7 @@ public class HttpDynamicSink extends AsyncDynamicTableSink<HttpSinkRequestEntry>
 
         HttpSinkBuilder<RowData> builder = HttpSink
             .<RowData>builder()
+            .setDeliveryGuarantee(tableOptions.get(DELIVERY_GUARANTEE))
             .setEndpointUrl(tableOptions.get(URL))
             .setSinkHttpClientBuilder(JavaNetSinkHttpClient::new)
             .setHttpPostRequestCallback(httpPostRequestCallback)

--- a/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSinkConnectorOptions.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicSinkConnectorOptions.java
@@ -2,6 +2,7 @@ package com.getindata.connectors.http.internal.table.sink;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 
 import static com.getindata.connectors.http.internal.config.HttpConnectorConfigConstants.SINK_REQUEST_CALLBACK_IDENTIFIER;
 
@@ -24,4 +25,12 @@ public class HttpDynamicSinkConnectorOptions {
         ConfigOptions.key(SINK_REQUEST_CALLBACK_IDENTIFIER)
             .stringType()
             .defaultValue(Slf4jHttpPostRequestCallbackFactory.IDENTIFIER);
+
+    public static final ConfigOption<DeliveryGuarantee> DELIVERY_GUARANTEE =
+        ConfigOptions.key("sink.delivery-guarantee")
+            .enumType(DeliveryGuarantee.class)
+            .defaultValue(DeliveryGuarantee.NONE)
+            .withDescription("Defines the delivery semantic for the HTTP sink. " +
+                "Accepted enumerations are 'at-least-once', and 'none'. " +
+                "'exactly-once' semantic is not supported.");
 }

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Properties;
 
 import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -66,6 +67,7 @@ public class HttpSinkInternalTest {
                 converter,
                 10, 1, 20,
                 1024L, 1000L, 1024L,
+                DeliveryGuarantee.NONE,
                 "http://test-endpoint.com",
                 mock(HttpPostRequestCallback.class),
                 mock(HeaderPreprocessor.class),

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkWriterTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkWriterTest.java
@@ -1,8 +1,8 @@
 package com.getindata.connectors.http.internal.sink;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -10,6 +10,7 @@ import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.connector.sink2.Sink.InitContext;
+import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.Counter;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -58,7 +60,9 @@ class HttpSinkWriterTest {
         when(metricGroup.getNumRecordsSendErrorsCounter()).thenReturn(errorCounter);
         when(metricGroup.getIOMetricGroup()).thenReturn(operatorIOMetricGroup);
         when(context.metricGroup()).thenReturn(metricGroup);
+    }
 
+    private void createHttpSinkWriter(DeliveryGuarantee deliveryGuarantee) {
         Collection<BufferedRequestState<HttpSinkRequestEntry>> stateBuffer = new ArrayList<>();
 
         this.httpSinkWriter = new HttpSinkWriter<>(
@@ -70,6 +74,7 @@ class HttpSinkWriterTest {
             10,
             10,
             10,
+            deliveryGuarantee,
             "http://localhost/client",
             httpClient,
             stateBuffer,
@@ -77,22 +82,208 @@ class HttpSinkWriterTest {
     }
 
     @Test
-    public void testErrorMetric() throws InterruptedException {
+    public void testErrorMetricWhenAllRequestsFailed() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.NONE);
 
         CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
         future.completeExceptionally(new Exception("Test Exception"));
 
         when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
 
-        HttpSinkRequestEntry request = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
         Consumer<List<HttpSinkRequestEntry>> requestResult =
             httpSinkRequestEntries -> log.info(String.valueOf(httpSinkRequestEntries));
 
-        List<HttpSinkRequestEntry> requestEntries = Collections.singletonList(request);
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2);
         this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
 
         // would be good to use Countdown Latch instead sleep...
         Thread.sleep(2000);
-        verify(errorCounter).inc(requestEntries.size());
+        verify(errorCounter).inc(2);
+    }
+
+    @Test
+    public void testErrorMetricWhenFailureRequestsOccur() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.NONE);
+
+        CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
+        future.complete(new SinkHttpClientResponse(
+                Arrays.asList(
+                        new SinkHttpClientResponse.ResponseItem(null, true),
+                        new SinkHttpClientResponse.ResponseItem(null, false))
+        ));
+
+        when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
+
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
+        HttpSinkRequestEntry request3 = new HttpSinkRequestEntry("PUT", "lorem".getBytes());
+        HttpSinkRequestEntry request4 = new HttpSinkRequestEntry("PUT", "ipsum".getBytes());
+        Consumer<List<HttpSinkRequestEntry>> requestResult =
+            httpSinkRequestEntries -> log.info(String.valueOf(httpSinkRequestEntries));
+
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2, request3, request4);
+        this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
+
+        // would be good to use Countdown Latch instead sleep...
+        Thread.sleep(2000);
+        verify(errorCounter).inc(1);
+    }
+
+    @Test
+    public void testRetryWhenAllRequestsFailed() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.AT_LEAST_ONCE);
+
+        CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(new Exception("Test Exception"));
+
+        when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
+
+        final List<HttpSinkRequestEntry> entriesToRetry = new ArrayList<>();
+
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
+        Consumer<List<HttpSinkRequestEntry>> requestResult = entriesToRetry::addAll;
+
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2);
+        this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
+
+        // would be good to use Countdown Latch instead sleep...
+        Thread.sleep(2000);
+        verify(errorCounter).inc(2);
+        assertEquals(2, entriesToRetry.size());
+    }
+
+
+    @Test
+    public void testRetryWhenAPartOfRequestsFailed() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.AT_LEAST_ONCE);
+
+        CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
+        future.complete(new SinkHttpClientResponse(
+                Arrays.asList(
+                        new SinkHttpClientResponse.ResponseItem(null, false),
+                        new SinkHttpClientResponse.ResponseItem(null, true))
+        ));
+
+        when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
+
+        final List<HttpSinkRequestEntry> entriesToRetry = new ArrayList<>();
+
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
+        Consumer<List<HttpSinkRequestEntry>> requestResult = entriesToRetry::addAll;
+
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2);
+        this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
+
+        // would be good to use Countdown Latch instead sleep...
+        Thread.sleep(2000);
+        verify(errorCounter).inc(1);
+        assertEquals(1, entriesToRetry.size());
+    }
+
+    @Test
+    public void testTemporalRequestsWithNoneGuaranteeDoNotRetry() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.NONE);
+
+        CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
+        future.complete(new SinkHttpClientResponse(
+                Arrays.asList(
+                        new SinkHttpClientResponse.ResponseItem(null, false),
+                        new SinkHttpClientResponse.ResponseItem(null, true))
+        ));
+
+        when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
+
+        final List<HttpSinkRequestEntry> entriesToRetry = new ArrayList<>();
+
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
+        Consumer<List<HttpSinkRequestEntry>> requestResult = entriesToRetry::addAll;
+
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2);
+        this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
+
+        // would be good to use Countdown Latch instead sleep...
+        Thread.sleep(2000);
+        verify(errorCounter).inc(1);
+        assertEquals(0, entriesToRetry.size());
+    }
+
+    @Test
+    public void testAllSuccessfulRequests() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.NONE);
+
+        CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
+        future.complete(new SinkHttpClientResponse(
+                Arrays.asList(
+                        new SinkHttpClientResponse.ResponseItem(null, true),
+                        new SinkHttpClientResponse.ResponseItem(null, true))
+        ));
+
+        when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
+
+        final List<HttpSinkRequestEntry> entriesToRetry = new ArrayList<>();
+
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
+        Consumer<List<HttpSinkRequestEntry>> requestResult = entriesToRetry::addAll;
+
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2);
+        this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
+
+        // would be good to use Countdown Latch instead sleep...
+        Thread.sleep(2000);
+        assertEquals(0, entriesToRetry.size());
+    }
+
+    @Test
+    public void testFailureRequestsWithAtLeastOnceGuarantee() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.AT_LEAST_ONCE);
+
+        CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
+        future.complete(new SinkHttpClientResponse(
+                Arrays.asList(
+                        new SinkHttpClientResponse.ResponseItem(null, false),
+                        new SinkHttpClientResponse.ResponseItem(null, true))
+        ));
+
+        when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
+
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
+        Consumer<List<HttpSinkRequestEntry>> requestResult =
+            httpSinkRequestEntries -> log.info(String.valueOf(httpSinkRequestEntries));
+
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2);
+        this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
+
+        // would be good to use Countdown Latch instead sleep...
+        Thread.sleep(2000);
+        verify(errorCounter).inc(1);
+    }
+
+    @Test
+    public void testUnsupportedDeliveryGuaranteeThrowsException() throws InterruptedException {
+        createHttpSinkWriter(DeliveryGuarantee.EXACTLY_ONCE);
+
+        CompletableFuture<SinkHttpClientResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(new Exception("Test Exception"));
+
+        when(httpClient.putRequests(anyList(), anyString())).thenReturn(future);
+
+        HttpSinkRequestEntry request1 = new HttpSinkRequestEntry("PUT", "hello".getBytes());
+        HttpSinkRequestEntry request2 = new HttpSinkRequestEntry("PUT", "world".getBytes());
+        Consumer<List<HttpSinkRequestEntry>> requestResult =
+            httpSinkRequestEntries -> log.info(String.valueOf(httpSinkRequestEntries));
+
+        List<HttpSinkRequestEntry> requestEntries = Arrays.asList(request1, request2);
+        this.httpSinkWriter.submitRequestEntries(requestEntries, requestResult);
+
+        // would be good to use Countdown Latch instead sleep...
+        Thread.sleep(2000);
+        verify(errorCounter).inc(2);
     }
 }

--- a/src/test/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicTableSinkFactoryTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/table/sink/HttpDynamicTableSinkFactoryTest.java
@@ -91,4 +91,44 @@ public class HttpDynamicTableSinkFactoryTest {
         assertThrows(ValidationException.class,
             () -> tEnv.executeSql("INSERT INTO http VALUES (1)").await());
     }
+
+    @Test
+    public void invalidSinkDeliveryGuaranteeOptionTests() {
+        final String invalidOptionCreateSql =
+            String.format(
+                "CREATE TABLE http (\n"
+                    + "  id bigint\n"
+                    + ") with (\n"
+                    + "  'connector' = '%s',\n"
+                    + "  'url' = '%s',\n"
+                    + "  'format' = 'json',\n"
+                    + "  'sink.delivery-guarantee' = 'invalid'\n"
+                    + ")",
+                HttpDynamicTableSinkFactory.IDENTIFIER,
+                "http://localhost/"
+            );
+        tEnv.executeSql(invalidOptionCreateSql);
+        assertThrows(ValidationException.class,
+            () -> tEnv.executeSql("INSERT INTO http VALUES (1)").await());
+    }
+
+    @Test
+    public void exactlyOnceDeliveryGuaranteeNotSupported() {
+        final String exactlyOnceCreateSql =
+            String.format(
+                "CREATE TABLE http (\n"
+                    + "  id bigint\n"
+                    + ") with (\n"
+                    + "  'connector' = '%s',\n"
+                    + "  'url' = '%s',\n"
+                    + "  'format' = 'json',\n"
+                    + "  'sink.delivery-guarantee' = 'exactly-once'\n"
+                    + ")",
+                HttpDynamicTableSinkFactory.IDENTIFIER,
+                "http://localhost/"
+            );
+        tEnv.executeSql(exactlyOnceCreateSql);
+        assertThrows(ValidationException.class,
+            () -> tEnv.executeSql("INSERT INTO http VALUES (1)").await());
+    }
 }


### PR DESCRIPTION
#### Description

`Add retry logic with delivery guarantees, retry all failed requests`

Resolves `182`

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
