### PR TITLE
[Bug Fix] http sink NEP checkpoint restore issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fixed http sink NEP issue when flink job restore from checkpoint.
 
 ## [0.23.0] - 2025-11-07
 

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
@@ -150,6 +150,11 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
                 Collection<BufferedRequestState<HttpSinkRequestEntry>> recoveredState)
             throws IOException {
 
+        ElementConverter<InputT, HttpSinkRequestEntry> elementConverter = getElementConverter();
+        if (elementConverter instanceof SchemaLifecycleAwareElementConverter) {
+            ((SchemaLifecycleAwareElementConverter<?, ?>) elementConverter).open(context);
+        }
+
         return new HttpSinkWriter<>(
             getElementConverter(),
             context,

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
@@ -143,7 +143,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
     private ElementConverter<InputT, HttpSinkRequestEntry> initElementConverterOfSchema(InitContext context) {
         ElementConverter<InputT, HttpSinkRequestEntry> elementConverter = getElementConverter();
         if (elementConverter instanceof SchemaLifecycleAwareElementConverter) {
-            ((SchemaLifecycleAwareElementConverter<?, ?>) elementConverter).open(context);
+            elementConverter.open(context);
         }
         return elementConverter;
     }

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkInternal.java
@@ -117,11 +117,7 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
     public StatefulSinkWriter<InputT, BufferedRequestState<HttpSinkRequestEntry>> createWriter(
             InitContext context) throws IOException {
 
-        ElementConverter<InputT, HttpSinkRequestEntry> elementConverter = getElementConverter();
-        if (elementConverter instanceof SchemaLifecycleAwareElementConverter) {
-            // This cast is needed for Flink 1.15.3 build
-            ((SchemaLifecycleAwareElementConverter<?, ?>) elementConverter).open(context);
-        }
+        ElementConverter<InputT, HttpSinkRequestEntry> elementConverter = initElementConverterOfSchema(context);
 
         return new HttpSinkWriter<>(
             elementConverter,
@@ -144,16 +140,21 @@ public class HttpSinkInternal<InputT> extends AsyncSinkBase<InputT, HttpSinkRequ
         );
     }
 
+    private ElementConverter<InputT, HttpSinkRequestEntry> initElementConverterOfSchema(InitContext context) {
+        ElementConverter<InputT, HttpSinkRequestEntry> elementConverter = getElementConverter();
+        if (elementConverter instanceof SchemaLifecycleAwareElementConverter) {
+            ((SchemaLifecycleAwareElementConverter<?, ?>) elementConverter).open(context);
+        }
+        return elementConverter;
+    }
+
     @Override
     public StatefulSinkWriter<InputT, BufferedRequestState<HttpSinkRequestEntry>> restoreWriter(
                 InitContext context,
                 Collection<BufferedRequestState<HttpSinkRequestEntry>> recoveredState)
             throws IOException {
 
-        ElementConverter<InputT, HttpSinkRequestEntry> elementConverter = getElementConverter();
-        if (elementConverter instanceof SchemaLifecycleAwareElementConverter) {
-            ((SchemaLifecycleAwareElementConverter<?, ?>) elementConverter).open(context);
-        }
+        initElementConverterOfSchema(context);
 
         return new HttpSinkWriter<>(
             getElementConverter(),

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
@@ -5,14 +5,13 @@ import com.getindata.connectors.http.SchemaLifecycleAwareElementConverter;
 import com.getindata.connectors.http.internal.HeaderPreprocessor;
 import com.getindata.connectors.http.internal.SinkHttpClient;
 import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
+import java.util.Collections;
+import java.util.Properties;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.Properties;
 
 import static org.mockito.Mockito.*;
 
@@ -27,7 +26,8 @@ public class HttpSinkInternalTest {
         OperatorIOMetricGroup mockIOMetricGroup = mock(OperatorIOMetricGroup.class);
         when(mockMetricGroup.getIOMetricGroup()).thenReturn(mockIOMetricGroup);
 
-        HttpSinkInternal<Object> httpSink = createTestSink((ElementConverter<Object, HttpSinkRequestEntry>) mockConverter);
+        HttpSinkInternal<Object> httpSink = createTestSink(
+                (ElementConverter<Object, HttpSinkRequestEntry>) mockConverter);
         httpSink.createWriter(mockContext);
         // com.getindata.connectors.http.internal.sink.HttpSinkInternal.initElementConverterOfSchema
         // org.apache.flink.connector.base.sink.writer.AsyncSinkWriter
@@ -42,7 +42,8 @@ public class HttpSinkInternalTest {
         SinkWriterMetricGroup mockMetricGroup = mock(SinkWriterMetricGroup.class);
         when(mockContext.metricGroup()).thenReturn(mockMetricGroup);
         when(mockMetricGroup.getIOMetricGroup()).thenReturn(mock(OperatorIOMetricGroup.class));
-        HttpSinkInternal<Object> httpSink = createTestSink((ElementConverter<Object, HttpSinkRequestEntry>) mockConverter);
+        HttpSinkInternal<Object> httpSink = createTestSink(
+                (ElementConverter<Object, HttpSinkRequestEntry>) mockConverter);
 
         httpSink.restoreWriter(mockContext, Collections.emptyList());
         // com.getindata.connectors.http.internal.sink.HttpSinkInternal.initElementConverterOfSchema
@@ -58,7 +59,8 @@ public class HttpSinkInternalTest {
 
         return new HttpSinkInternal<>(
                 converter,
-                10, 1, 20, 1024L, 1000L, 1024L,
+                10, 1, 20,
+                1024L, 1000L, 1024L,
                 "http://test-endpoint.com",
                 mock(HttpPostRequestCallback.class),
                 mock(HeaderPreprocessor.class),

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
@@ -1,0 +1,70 @@
+package com.getindata.connectors.http.internal.sink;
+
+import com.getindata.connectors.http.HttpPostRequestCallback;
+import com.getindata.connectors.http.SchemaLifecycleAwareElementConverter;
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
+import com.getindata.connectors.http.internal.SinkHttpClient;
+import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.mockito.Mockito.*;
+
+public class HttpSinkInternalTest {
+
+    @Test
+    void testCreateWriterInitializesLifecycleAwareConverter() throws Exception {
+        SchemaLifecycleAwareElementConverter<?, ?> mockConverter = mock(SchemaLifecycleAwareElementConverter.class);
+        Sink.InitContext mockContext = mock(Sink.InitContext.class);
+        SinkWriterMetricGroup mockMetricGroup = mock(SinkWriterMetricGroup.class);
+        when(mockContext.metricGroup()).thenReturn(mockMetricGroup);
+        OperatorIOMetricGroup mockIOMetricGroup = mock(OperatorIOMetricGroup.class);
+        when(mockMetricGroup.getIOMetricGroup()).thenReturn(mockIOMetricGroup);
+
+        HttpSinkInternal<Object> httpSink = createTestSink((ElementConverter<Object, HttpSinkRequestEntry>) mockConverter);
+        httpSink.createWriter(mockContext);
+        // com.getindata.connectors.http.internal.sink.HttpSinkInternal.initElementConverterOfSchema
+        // org.apache.flink.connector.base.sink.writer.AsyncSinkWriter
+        verify(mockConverter, times(2)).open(mockContext);
+    }
+
+    @Test
+    void testRestoreWriterInitializesLifecycleAwareConverter() throws Exception {
+
+        SchemaLifecycleAwareElementConverter<?, ?> mockConverter = mock(SchemaLifecycleAwareElementConverter.class);
+        Sink.InitContext mockContext = mock(Sink.InitContext.class);
+        SinkWriterMetricGroup mockMetricGroup = mock(SinkWriterMetricGroup.class);
+        when(mockContext.metricGroup()).thenReturn(mockMetricGroup);
+        when(mockMetricGroup.getIOMetricGroup()).thenReturn(mock(OperatorIOMetricGroup.class));
+        HttpSinkInternal<Object> httpSink = createTestSink((ElementConverter<Object, HttpSinkRequestEntry>) mockConverter);
+
+        httpSink.restoreWriter(mockContext, Collections.emptyList());
+        // com.getindata.connectors.http.internal.sink.HttpSinkInternal.initElementConverterOfSchema
+        // org.apache.flink.connector.base.sink.writer.AsyncSinkWriter
+        verify(mockConverter, times(2)).open(mockContext);
+    }
+
+
+    private HttpSinkInternal<Object> createTestSink(ElementConverter<Object, HttpSinkRequestEntry> converter) {
+        SinkHttpClientBuilder mockClientBuilder = mock(SinkHttpClientBuilder.class);
+        when(mockClientBuilder.build(any(), any(), any(), any()))
+                .thenReturn(mock(SinkHttpClient.class));
+
+        return new HttpSinkInternal<>(
+                converter,
+                10, 1, 20, 1024L, 1000L, 1024L,
+                "http://test-endpoint.com",
+                mock(HttpPostRequestCallback.class),
+                mock(HeaderPreprocessor.class),
+                mockClientBuilder,
+                new Properties()
+        );
+    }
+
+}

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkInternalTest.java
@@ -1,19 +1,24 @@
 package com.getindata.connectors.http.internal.sink;
 
-import com.getindata.connectors.http.HttpPostRequestCallback;
-import com.getindata.connectors.http.SchemaLifecycleAwareElementConverter;
-import com.getindata.connectors.http.internal.HeaderPreprocessor;
-import com.getindata.connectors.http.internal.SinkHttpClient;
-import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
 import java.util.Collections;
 import java.util.Properties;
+
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import static org.mockito.Mockito.*;
+import com.getindata.connectors.http.HttpPostRequestCallback;
+import com.getindata.connectors.http.SchemaLifecycleAwareElementConverter;
+import com.getindata.connectors.http.internal.HeaderPreprocessor;
+import com.getindata.connectors.http.internal.SinkHttpClient;
+import com.getindata.connectors.http.internal.SinkHttpClientBuilder;
 
 public class HttpSinkInternalTest {
 


### PR DESCRIPTION
#### Description
The target of this PR is to fix the below issue, you can check the detail following the link. The root cause is the mapper is null, the method **open()** can't be initiated when the job restore from the checkpoint. We must initiate it on **restoreWriter** just like **createWriter**.


![img_v3_02sd_4e4d8b69-34ef-4ae4-9bd0-9f0bf0edbf8g](https://github.com/user-attachments/assets/633d0cf8-45ed-4b8f-b28f-6ccd58f2a17a)


#### Target
Resolves [issue 195](https://github.com/getindata/flink-http-connector/issues/195)

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
