### PR TITLE
HTTP-193 Pass format options to the http response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- allow format options to be applied to the http response decoding.
+
 ## [0.24.0] - 2025-11-26
 
 -   Add UNABLE_TO_DESERIALIZE_RESPONSE http-completion-state. If you have used 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,12 @@ POST, PUT and GET operations. This query creator allows you to issue json reques
 your own custom http connector. The mappings from columns to the json request are supplied in the query creator configuration
 parameters `gid.connector.http.request.query-param-fields`, `gid.connector.http.request.body-fields` and `gid.connector.http.request.url-map`. 
 
+### Format considerations
+
+#### For http requests
 In order to use custom format, user has to specify option `'lookup-request.format' = 'customFormatName'`, where `customFormatName` is the identifier of custom format factory.
 
-Additionally, it is possible to pass query format options from table's DDL.
+Additionally, it is possible to pass custom query format options from table's DDL.
 This can be done by using option like so: `'lookup-request.format.customFormatName.customFormatProperty' = 'propertyValue'`, for example
 `'lookup-request.format.customFormatName.fail-on-missing-field' = 'true'`.
 
@@ -165,6 +168,14 @@ DynamicTableFactory.Context context, ReadableConfig formatOptions)` method in `R
 
 With default configuration, Flink-Json format is used for `GenericGetQueryCreator`, all options defined in [json-format](https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/json/)
 can be passed through table DDL. For example `'lookup-request.format.json.fail-on-missing-field' = 'true'`. In this case, format identifier is `json`.
+
+#### For http responses
+Specify your format options at the top level. For example:
+```roomsql
+       'format' = 'json',
+       'json.ignore-parse-errors' = 'true',
+```
+
 
 #### Timeouts
 Lookup Source is guarded by two timeout timers. First one is specified by Flink's AsyncIO operator that executes `AsyncTableFunction`.

--- a/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpTableLookupFunction.java
+++ b/src/main/java/com/getindata/connectors/http/internal/table/lookup/HttpTableLookupFunction.java
@@ -81,7 +81,7 @@ public class HttpTableLookupFunction extends LookupFunction {
         HttpRowDataWrapper httpRowDataWrapper = client.pull(keyRow);
         Collection<RowData> httpCollector = httpRowDataWrapper.getData();
 
-        int physicalArity=-1;
+        int physicalArity = -1;
 
         GenericRowData producedRow = null;
         if (httpRowDataWrapper.shouldIgnore()) {
@@ -103,10 +103,15 @@ public class HttpTableLookupFunction extends LookupFunction {
             }
         }
         // if we did not get the physical arity from the http response physical row then get it from the
-        // producedDataType. which is set when we have metadata
-        if (physicalArity == -1 && producedDataType != null ) {
-            List<LogicalType> childrenLogicalTypes=producedDataType.getLogicalType().getChildren();
-            physicalArity=childrenLogicalTypes.size()-metadataArity;
+        // producedDataType. which is set when we have metadata or when there's no data
+        if (physicalArity == -1) {
+            if (producedDataType != null) {
+                List<LogicalType> childrenLogicalTypes = producedDataType.getLogicalType().getChildren();
+                physicalArity = childrenLogicalTypes.size() - metadataArity;
+            } else {
+                // If producedDataType is null and we have no data, return the same way as ignore.
+                return Collections.emptyList();
+            }
         }
         // if there was no data, create an empty producedRow
         if (producedRow == null) {


### PR DESCRIPTION
#### Description

allow format options to be applied to the http response decoding.

Resolves `HTTP-193`

##### PR Checklist
- [y] Tests added
- [y] [Changelog](CHANGELOG.md) updated 
