### PR TITLE
HttpPostRequestCallback adds open and close methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Simplify the implementation of deserialize change added in the last release and add proper testing.
+ 
+- HttpPostRequestCallback adds open and close methods
 
 ## [0.25.0] - 2026-01-09
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,35 @@ A default implementation that logs those pairs as *INFO* level logs using Slf4j 
 If you would like to log more http content (that maybe contain sensitive information), then you can provide a customized version
 of this callback; for inspiration on how to customize in this way, look back in the git history of this file.
 
+The `HttpPostRequestCallback` interface now includes `open()` and `close()` lifecycle methods that are called when the connector is initialized and closed, respectively. These methods can be overridden to initialize and clean up resources such as database connections, caches, or other stateful components that the callback might require.
+
+Here's an example of how to implement these lifecycle methods:
+
+```java
+public class CustomHttpPostRequestCallback implements HttpPostRequestCallback<HttpRequest> {
+
+    @Override
+    public void open() {
+        // Initialize resources when the callback is opened
+    }
+
+    @Override
+    public void call(
+            HttpResponse<String> response,
+            HttpRequest requestEntry,
+            String endpointUrl,
+            Map<String, String> headerMap) {
+        // Process the HTTP response
+        System.out.println("Processing HTTP response: " + response.statusCode());
+    }
+
+    @Override
+    public void close() {
+        // Clean up resources
+    }
+}
+```
+
 - Http Lookup Source processes responses that it gets from the HTTP endpoint along their respective requests. One can customize the
 behaviour of the additional stage of processing done by Table Function API by implementing
 [HttpPostRequestCallback](src/main/java/com/getindata/connectors/http/HttpPostRequestCallback.java) and

--- a/src/main/java/com/getindata/connectors/http/HttpPostRequestCallback.java
+++ b/src/main/java/com/getindata/connectors/http/HttpPostRequestCallback.java
@@ -13,6 +13,10 @@ import java.util.Map;
  * @param <RequestT> type of the HTTP request wrapper
  */
 public interface HttpPostRequestCallback<RequestT> extends Serializable {
+
+
+    default void open(){}
+
     /**
      * Process HTTP request and the matching response.
      *  @param response HTTP response
@@ -26,4 +30,6 @@ public interface HttpPostRequestCallback<RequestT> extends Serializable {
         String endpointUrl,
         Map<String, String> headerMap
     );
+
+    default void close(){}
 }

--- a/src/main/java/com/getindata/connectors/http/internal/SinkHttpClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/SinkHttpClient.java
@@ -13,6 +13,8 @@ import com.getindata.connectors.http.internal.sink.HttpSinkWriter;
  */
 public interface SinkHttpClient {
 
+    void open();
+
     /**
      * Sends HTTP requests to an external web service.
      *
@@ -25,4 +27,6 @@ public interface SinkHttpClient {
         List<HttpSinkRequestEntry> requestEntries,
         String endpointUrl
     );
+
+    void close();
 }

--- a/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkWriter.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/HttpSinkWriter.java
@@ -77,6 +77,8 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
                 sinkWriterThreadPollSize,
                 new ExecutorThreadFactory(
                     "http-sink-writer-worker", ThreadUtils.LOGGING_EXCEPTION_HANDLER));
+
+        this.sinkHttpClient.open();
     }
 
     // TODO: Reintroduce retries by adding backoff policy
@@ -125,6 +127,7 @@ public class HttpSinkWriter<InputT> extends AsyncSinkWriter<InputT, HttpSinkRequ
 
     @Override
     public void close() {
+        sinkHttpClient.close();
         sinkWriterThreadPool.shutdownNow();
         super.close();
     }

--- a/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
+++ b/src/main/java/com/getindata/connectors/http/internal/sink/httpclient/JavaNetSinkHttpClient.java
@@ -76,6 +76,16 @@ public class JavaNetSinkHttpClient implements SinkHttpClient {
     }
 
     @Override
+    public void open() {
+        this.httpPostRequestCallback.open();
+    }
+
+    @Override
+    public void close() {
+        this.httpPostRequestCallback.close();
+    }
+
+    @Override
     public CompletableFuture<SinkHttpClientResponse> putRequests(
         List<HttpSinkRequestEntry> requestEntries,
         String endpointUrl) {

--- a/src/test/java/com/getindata/connectors/http/TestLifeCyclePostRequestCallbackFactory.java
+++ b/src/test/java/com/getindata/connectors/http/TestLifeCyclePostRequestCallbackFactory.java
@@ -1,0 +1,27 @@
+package com.getindata.connectors.http;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.flink.configuration.ConfigOption;
+
+import com.getindata.connectors.http.internal.sink.httpclient.HttpRequest;
+
+public class TestLifeCyclePostRequestCallbackFactory implements HttpPostRequestCallbackFactory<HttpRequest> {
+
+    public static final String TEST_LIFE_CYCLE_POST_REQUEST_CALLBACK_IDENT = "test-lifecycle-request-callback";
+
+    @Override
+    public HttpPostRequestCallback<HttpRequest> createHttpPostRequestCallback() {
+        return new HttpPostRequestCallbackFactoryTest.TestLifeCyclePostRequestCallback();
+    }
+
+    @Override
+    public String factoryIdentifier() { return TEST_LIFE_CYCLE_POST_REQUEST_CALLBACK_IDENT; }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() { return new HashSet<>(); }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() { return new HashSet<>(); }
+}

--- a/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
+++ b/src/test/java/com/getindata/connectors/http/internal/sink/HttpSinkBuilderTest.java
@@ -66,6 +66,12 @@ public class HttpSinkBuilderTest {
         MockHttpClient() {}
 
         @Override
+        public void open() {}
+
+        @Override
+        public void close() {}
+
+        @Override
         public CompletableFuture<SinkHttpClientResponse> putRequests(
             List<HttpSinkRequestEntry> requestEntries, String endpointUrl) {
             throw new RuntimeException("Mock implementation of HttpClient");

--- a/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,4 +1,5 @@
 com.getindata.connectors.http.TestPostRequestCallbackFactory
+com.getindata.connectors.http.TestLifeCyclePostRequestCallbackFactory
 com.getindata.connectors.http.TestLookupPostRequestCallbackFactory
 com.getindata.connectors.http.internal.table.lookup.querycreators.CustomFormatFactory
 com.getindata.connectors.http.internal.table.lookup.querycreators.CustomJsonFormatFactory


### PR DESCRIPTION
add CHANGELOG

#### Description

The open() and close() life cycle methods are added to the HttpPostRequestCallback interface. It is very necessary when we need to initialize resources such as database connections in the callback interface.

##### PR Checklist
- [ y] Tests added
- [ y] [Changelog](CHANGELOG.md) updated 
